### PR TITLE
Create unified Explore page (merge Map & Globe)

### DIFF
--- a/assets/js/globe.js
+++ b/assets/js/globe.js
@@ -279,6 +279,11 @@ function attachEvents() {
         document.getElementById('globeYearFrom').value = '';
         document.getElementById('globeYearTo').value = '';
         document.querySelector('input[name="globeMetric"][value="total"]').checked = true;
+        const globeView = document.querySelector('input[name="exploreView"][value="globe"]');
+        if (globeView) {
+            globeView.checked = true;
+            globe.setProjection('globe');
+        }
         updateGlobe();
     });
 }

--- a/assets/js/globe.js
+++ b/assets/js/globe.js
@@ -262,6 +262,13 @@ function attachEvents() {
         document.getElementById(id).addEventListener('change', updateGlobe);
     });
 
+    document.querySelectorAll('input[name="exploreView"]').forEach(input => {
+        input.addEventListener('change', event => {
+            const projection = event.target.value === 'map' ? 'mercator' : 'globe';
+            globe.setProjection(projection);
+        });
+    });
+
     document.querySelectorAll('input[name="globeMetric"]').forEach(input => {
         input.addEventListener('change', updateGlobe);
     });

--- a/data-analysis.html
+++ b/data-analysis.html
@@ -14,8 +14,7 @@
     <nav class="navbar bg-base-300">
         <div class="navbar-start">
             <ul class="menu menu-horizontal px-1 gap-x-12">
-                <li><a class="btn btn-primary" href="index.html">Map</a></li>
-                <li><a class="btn btn-primary" href="globe.html">Globe</a></li>
+                <li><a class="btn btn-primary" href="index.html">Explore</a></li>
                 <li><a class="btn btn-primary" href="data-analysis.html">Data</a></li>
                 <li><a class="btn btn-primary" href="submit-artwork.html">Submit</a></li>
             </ul>

--- a/globe.html
+++ b/globe.html
@@ -20,8 +20,7 @@
         </div>
         <div class="navbar-center">
             <ul class="menu menu-horizontal px-1 gap-x-4">
-                <li><a class="btn btn-primary" href="index.html"><i class="ti ti-map-2 text-xl"></i>Map</a></li>
-                <li><a class="btn btn-primary" href="globe.html"><i class="ti ti-world text-xl"></i>Globe</a></li>
+                <li><a class="btn btn-primary" href="index.html"><i class="ti ti-compass text-xl"></i>Explore</a></li>
                 <li><a class="btn btn-primary" href="data-analysis.html"><i class="ti ti-chart-dots-2 text-xl"></i>Data</a></li>
                 <li><a class="btn btn-primary" href="submit-artwork.html"><i class="ti ti-upload text-xl"></i>Submit</a></li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -3,157 +3,118 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>eco:nection</title>
-    <!-- Mapbox GL CSS -->
-    <link href="https://api.mapbox.com/mapbox-gl-js/v2.3.1/mapbox-gl.css" rel="stylesheet" />
-    <!-- Custom CSS for your map page -->
-    <link rel="stylesheet" href="style.css">
-    <!-- DaisyUI -->
-    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.14/dist/full.min.css" rel="stylesheet" type="text/css" />
+    <title>eco:nection - Explore</title>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.14/dist/full.min.css" rel="stylesheet" type="text/css">
     <script src="https://cdn.tailwindcss.com"></script>
-    <!-- Tabler Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css">
+    <link rel="stylesheet" href="style.css">
 </head>
-<body class="h-full flex flex-col">
+<body class="h-full flex flex-col bg-base-100">
     <nav class="navbar bg-base-300">
         <div class="navbar-start">
-            <div class="dropdown">
-                <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
-                    <i class="ti ti-menu text-xl"></i>
-                </div>
-                <ul
-                    tabindex="0"
-                    class="menu menu-sm dropdown-content gap-y-3 bg-base-300 rounded-box z-10 mt-3 w-44 shadow">
-                    <li>
-                        <a class="btn btn-primary" href="index.html">
-                            <i class="ti ti-map-2 text-xl"></i>
-                            <span>Map</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a class="btn btn-primary" href="globe.html">
-                            <i class="ti ti-world text-xl"></i>
-                            <span>Globe</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a class="btn btn-primary" href="data-analysis.html">
-                            <i class="ti ti-chart-dots-2 text-xl"></i>
-                            <span>Data</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a class="btn btn-primary" href="submit-artwork.html">
-                            <i class="ti ti-upload text-xl"></i>
-                            <span>Submit</span>
-                        </a>
-                    </li>
-                    <div class="divider my-0"></div>
-                    <li>
-                        <a href="https://github.com/PeiaKassio/eco-nection" class="btn btn-outline btn-secondary lg:hidden">
-                            <i class="ti ti-brand-github text-xl"></i>
-                            Contribute
-                        </a>
-                    </li>
-                </ul>
-            </div>
-            <div class="flex mx-3 gap-3 justify-center hidden lg:flex">
+            <div class="flex mx-3 gap-3 justify-center">
                 <i class="ti ti-affiliate text-3xl text-primary"></i>
                 <span class="text-2xl subpixel-antialiased">eco:nection</span>
             </div>
         </div>
         <div class="navbar-center">
-            <div class="flex mx-3 gap-3 justify-center lg:hidden">
-                <i class="ti ti-affiliate text-3xl text-primary"></i>
-                <span class="text-2xl subpixel-antialiased">eco:nection</span>
-            </div>
-            <ul class="hidden lg:flex menu menu-horizontal px-1 gap-x-12">
-                <li>
-                    <a class="btn btn-primary" href="index.html">
-                        <i class="ti ti-map-2 text-xl"></i>
-                        Map
-                    </a>
-                </li>
-                <li>
-                    <a class="btn btn-primary" href="globe.html">
-                        <i class="ti ti-world text-xl"></i>
-                        Globe
-                    </a>
-                </li>
-                <li>
-                    <a class="btn btn-primary" href="data-analysis.html">
-                        <i class="ti ti-chart-dots-2 text-xl"></i>
-                        Data
-                    </a>
-                </li>
-                <li>
-                    <a class="btn btn-primary" href="submit-artwork.html">
-                        <i class="ti ti-upload text-xl"></i>
-                        Submit
-                    </a>
-                </li>
+            <ul class="menu menu-horizontal px-1 gap-x-4">
+                <li><a class="btn btn-primary" href="index.html"><i class="ti ti-compass text-xl"></i>Explore</a></li>
+                <li><a class="btn btn-primary" href="data-analysis.html"><i class="ti ti-chart-dots-2 text-xl"></i>Data</a></li>
+                <li><a class="btn btn-primary" href="submit-artwork.html"><i class="ti ti-upload text-xl"></i>Submit</a></li>
             </ul>
         </div>
-        <div class="navbar-end">
-            <a href="https://github.com/PeiaKassio/eco-nection" class="btn btn-outline btn-secondary hidden lg:flex">
-                <i class="ti ti-brand-github text-xl"></i>
-                Contribute
-            </a>
-        </div>
+        <div class="navbar-end"></div>
     </nav>
 
-    <!-- Map container where the map will be displayed -->
-    <div id="map" class="flex grow relative">
-        <div class="absolute top-3 left-3 z-10 dropdown dropdown-start">
-            <div tabindex="0" role="button" class="btn btn-primary btn-circle">
-                <div class="w-10 rounded-full">
-                    <i class="ti ti-filter text-xl"></i>
+    <main class="globe-shell">
+        <section id="globeMap" class="globe-map"></section>
+
+        <aside class="globe-panel bg-base-200">
+            <div class="flex items-center justify-between gap-3">
+                <h1 class="text-2xl font-bold">Explore</h1>
+                <button id="resetGlobeFilters" class="btn btn-sm btn-outline btn-primary">
+                    <i class="ti ti-refresh text-lg"></i>
+                    Reset
+                </button>
+            </div>
+
+            <div class="mt-4">
+                <span class="label-text">View</span>
+                <div class="join w-full mt-1" role="group" aria-label="Choose map projection">
+                    <input class="join-item btn btn-sm flex-1" type="radio" name="exploreView" value="globe" aria-label="Globe View" checked>
+                    <input class="join-item btn btn-sm flex-1" type="radio" name="exploreView" value="map" aria-label="Map View">
                 </div>
             </div>
-            <ul tabindex="0" class="menu menu-sm dropdown-content bg-base-100 rounded-box z-10 m-3 gap-y-2 shadow">
-                <li>
-                    <label class="input input-bordered input-sm flex items-center gap-2">
-                        <input type="text" id="search-bar" class="grow" placeholder="Search by title or description" />
-                        <i class="ti ti-search text-xl"></i>
-                    </label>
-                </li>
-                <!--<li>
-                    <select id="tag-filter" class="select select-bordered select-sm w-full max-w-xs" multiple>
-                        <option selected value="">All Topics</option>
-                        <!-- Dynamische Optionen werden hier durch JavaScript hinzugefügt 
-                    </select>
-                </li>-->
-                <li>
-                    <select id="cluster-filter" class="select select-bordered select-sm w-full max-w-xs" multiple>
-                        <option selected value="">All Clusters</option>
-                        <!-- Dynamische Optionen werden hier durch JavaScript hinzugefügt -->
-                    </select>
-                </li>
-                <li>
-                    <select id="artform-filter" class="select select-bordered select-sm w-full max-w-xs" multiple>
-                        <option value="">All Art Forms</option>
-                        <!-- Dynamische Optionen werden hier durch JavaScript hinzugefügt -->
-                    </select>
-                </li>
-                <li>
-                    <h3 class="text-sm font-semibold">By Year</h3>
-                    <div class="flex space-x-2">
-                        <input id="year-from" type="number" placeholder="From" class="input input-bordered input-sm w-1/2" min="1800" max="2025">
-                        <input id="year-to" type="number" placeholder="To" class="input input-bordered input-sm w-1/2" min="1800" max="2025">
-                    </div>
-                </li>
-                <li>
-                    <button id="reset-filters" class="btn btn-outline btn-sm btn-primary">Reset Filters</button>
-                </li>
-            </ul>
-        </div>
-    </div>
 
-    <!-- Mapbox GL JS and Custom Script -->
-    <script src="https://api.mapbox.com/mapbox-gl-js/v2.3.1/mapbox-gl.js"></script>
-    <script src="assets/js/script.js"></script>
-    <div id="artwork-count" style="font-size: 1.2em; font-weight: bold; margin-bottom: 10px;"></div>
+            <label class="form-control mt-4">
+                <span class="label-text">Search</span>
+                <input id="globeSearch" type="search" class="input input-bordered" placeholder="Title, artist, location">
+            </label>
 
+            <label class="form-control mt-4">
+                <span class="label-text">Topic Cluster</span>
+                <select id="globeCluster" class="select select-bordered">
+                    <option value="">All clusters</option>
+                </select>
+            </label>
+
+            <div class="grid grid-cols-2 gap-3 mt-4">
+                <label class="form-control">
+                    <span class="label-text">From year</span>
+                    <input id="globeYearFrom" type="number" class="input input-bordered" min="1800" max="2100">
+                </label>
+                <label class="form-control">
+                    <span class="label-text">To year</span>
+                    <input id="globeYearTo" type="number" class="input input-bordered" min="1800" max="2100">
+                </label>
+            </div>
+
+            <div class="mt-4">
+                <span class="label-text">Metric</span>
+                <div class="join w-full mt-1">
+                    <input class="join-item btn btn-sm flex-1" type="radio" name="globeMetric" value="total" aria-label="Total" checked>
+                    <input class="join-item btn btn-sm flex-1" type="radio" name="globeMetric" value="perCapita" aria-label="Per 1M people">
+                </div>
+            </div>
+
+            <div class="stats stats-vertical lg:stats-horizontal shadow w-full mt-5">
+                <div class="stat">
+                    <div class="stat-title">Visible artworks</div>
+                    <div id="globeArtworkCount" class="stat-value text-primary">0</div>
+                </div>
+                <div class="stat">
+                    <div class="stat-title">Countries</div>
+                    <div id="globeCountryCount" class="stat-value text-secondary">0</div>
+                </div>
+            </div>
+
+            <section class="mt-5">
+                <h2 class="text-xl font-semibold">Top Countries</h2>
+                <div id="globeCountryRanking" class="globe-ranking mt-3"></div>
+            </section>
+
+            <section class="mt-5">
+                <h2 class="text-xl font-semibold">Continents</h2>
+                <div id="globeContinentRanking" class="globe-ranking mt-3"></div>
+            </section>
+
+            <section class="mt-5 rounded-box border border-base-300 bg-base-100 p-4">
+                <h2 class="text-xl font-semibold">Help improve this archive</h2>
+                <p class="mt-2 text-sm opacity-80">Community contributions make eco:nection more complete and balanced.</p>
+                <ul class="mt-3 grid gap-2 text-sm">
+                    <li><i class="ti ti-link-plus text-primary"></i> Add missing sources</li>
+                    <li><i class="ti ti-photo-plus text-primary"></i> Add missing images</li>
+                    <li><i class="ti ti-world-plus text-primary"></i> Suggest artworks from underrepresented countries</li>
+                    <li><i class="ti ti-tags text-primary"></i> Review topic tags</li>
+                    <li><i class="ti ti-heart-handshake text-primary"></i> Help complete this archive</li>
+                </ul>
+            </section>
+        </aside>
+    </main>
+
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <script src="assets/js/globe.js"></script>
 </body>
-
 </html>

--- a/index.html
+++ b/index.html
@@ -13,13 +13,29 @@
 <body class="h-full flex flex-col bg-base-100">
     <nav class="navbar bg-base-300">
         <div class="navbar-start">
-            <div class="flex mx-3 gap-3 justify-center">
+            <div class="dropdown lg:hidden">
+                <div tabindex="0" role="button" class="btn btn-ghost" aria-label="Open navigation menu">
+                    <i class="ti ti-menu-2 text-2xl"></i>
+                </div>
+                <ul
+                    tabindex="0"
+                    class="menu menu-sm dropdown-content gap-y-3 bg-base-300 rounded-box z-20 mt-3 w-48 shadow">
+                    <li><a class="btn btn-primary justify-start" href="index.html"><i class="ti ti-compass text-xl"></i>Explore</a></li>
+                    <li><a class="btn btn-primary justify-start" href="data-analysis.html"><i class="ti ti-chart-dots-2 text-xl"></i>Data</a></li>
+                    <li><a class="btn btn-primary justify-start" href="submit-artwork.html"><i class="ti ti-upload text-xl"></i>Submit</a></li>
+                </ul>
+            </div>
+            <div class="hidden lg:flex mx-3 gap-3 justify-center">
                 <i class="ti ti-affiliate text-3xl text-primary"></i>
                 <span class="text-2xl subpixel-antialiased">eco:nection</span>
             </div>
         </div>
         <div class="navbar-center">
-            <ul class="menu menu-horizontal px-1 gap-x-4">
+            <div class="flex mx-3 gap-3 justify-center lg:hidden">
+                <i class="ti ti-affiliate text-3xl text-primary"></i>
+                <span class="text-2xl subpixel-antialiased">eco:nection</span>
+            </div>
+            <ul class="hidden lg:flex menu menu-horizontal px-1 gap-x-4">
                 <li><a class="btn btn-primary" href="index.html"><i class="ti ti-compass text-xl"></i>Explore</a></li>
                 <li><a class="btn btn-primary" href="data-analysis.html"><i class="ti ti-chart-dots-2 text-xl"></i>Data</a></li>
                 <li><a class="btn btn-primary" href="submit-artwork.html"><i class="ti ti-upload text-xl"></i>Submit</a></li>
@@ -110,6 +126,10 @@
                     <li><i class="ti ti-tags text-primary"></i> Review topic tags</li>
                     <li><i class="ti ti-heart-handshake text-primary"></i> Help complete this archive</li>
                 </ul>
+                <a class="btn btn-primary btn-sm mt-4" href="submit-artwork.html">
+                    <i class="ti ti-upload text-lg"></i>
+                    Contribute an artwork
+                </a>
             </section>
         </aside>
     </main>

--- a/submit-artwork.html
+++ b/submit-artwork.html
@@ -19,8 +19,7 @@
         </div>
         <div class="navbar-center">
             <ul class="menu menu-horizontal px-1 gap-x-4">
-                <li><a class="btn btn-primary" href="index.html"><i class="ti ti-map-2 text-xl"></i>Map</a></li>
-                <li><a class="btn btn-primary" href="globe.html"><i class="ti ti-world text-xl"></i>Globe</a></li>
+                <li><a class="btn btn-primary" href="index.html"><i class="ti ti-compass text-xl"></i>Explore</a></li>
                 <li><a class="btn btn-primary" href="data-analysis.html"><i class="ti ti-chart-dots-2 text-xl"></i>Data</a></li>
                 <li><a class="btn btn-primary" href="submit-artwork.html"><i class="ti ti-upload text-xl"></i>Submit</a></li>
             </ul>


### PR DESCRIPTION
### Motivation
- Present a single unified "Explore" entrypoint by merging the separate Map and Globe experiences to simplify navigation and maintenance. 
- Reuse the globe implementation because it already contains the clearer filter, ranking, metric and data enrichment logic. 
- Provide a simple in-page switch so users can choose Globe vs Map projection without duplicating data logic. 

### Description
- Replaced the old `index.html` map page with a globe-based Explore page that uses the `globeMap` container and includes the existing search, topic cluster, year, metric, ranking and data UI. 
- Added a `Globe View | Map View` radio switch in the Explore sidebar and wired it to toggle the shared Mapbox instance projection between `globe` and `mercator` using `globe.setProjection(...)` in `assets/js/globe.js`. 
- Added a small community panel titled "Help improve this archive" with prompts for missing sources, images, underrepresented countries, topic tags, and completing the archive. 
- Updated top-level navigation labels on other pages to use a single `Explore` item (replacing separate Map/Globe links) and standardized Mapbox GL to v2.15.0 usage with `assets/js/globe.js` as the active script for the Explore page. 

### Testing
- Ran `node --check assets/js/globe.js` and the check succeeded. 
- Parsed HTML for `index.html`, `globe.html`, `data-analysis.html` and `submit-artwork.html` using Python`s `html.parser` and the check passed. 
- Ran `git diff --check` to validate whitespace/diff issues and it reported no problems. 
- Attempted an automated browser screenshot via Playwright (`npx playwright screenshot ...`) against a local `python3 -m http.server`, but the Playwright install failed due to an npm registry policy `403`, so the headless screenshot step could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bb42bc1508330a2a3ec133809d089)