### PR TITLE
Refactor shared eco data helpers

### DIFF
--- a/assets/js/data-analysis.js
+++ b/assets/js/data-analysis.js
@@ -9,27 +9,11 @@ let selectedContinent = [];
 let selectedCountry = [];
 let selectedTopics = [];
 let selectedMetric = 'total';
-
-const COUNTRY_ALIASES = {
-    "DRC (Africa leg)": "Democratic Republic of the Congo",
-    "Dead Sea region (Israel/Jordan Rift)": "Israel",
-    "Dead Sea region (Jordan/Israel)": "Israel",
-    "Tropical regions": "Other",
-    "Various exhibitions": "Other",
-    "United States Minor Outlying Islands": "Other"
-};
+const { loadSharedData, normalizeText, parseYear } = EcoData;
 
 // -----------------------------
 // Utils für Suche & Debounce
 // -----------------------------
-function normalizeStr(s) {
-  return (s || "")
-    .toString()
-    .normalize("NFD")
-    .replace(/\p{Diacritic}/gu, "")
-    .toLowerCase();
-}
-
 function debounce(fn, wait = 120) {
   let t;
   return (...args) => {
@@ -39,24 +23,15 @@ function debounce(fn, wait = 120) {
 }
 
 function getCountryFromLocation(location) {
-    const rawLocation = (location || "").trim();
-
-    if (COUNTRY_ALIASES[rawLocation]) return COUNTRY_ALIASES[rawLocation];
-    if (continentMapping[rawLocation] || countryPopulation[rawLocation]) return rawLocation;
-
-    const lastPart = rawLocation.split(",").pop().trim();
-    return COUNTRY_ALIASES[lastPart] || lastPart || "Other";
+    return EcoData.getCountryFromLocation(location, continentMapping, countryPopulation);
 }
 
 function getContinentForCountry(country) {
-    return continentMapping[country] || continentMapping[country?.toLowerCase()] || "Other";
+    return EcoData.getContinentForCountry(country, continentMapping);
 }
 
 function getArtworkClusters(artwork) {
-    const topics = artwork.properties.tags?.topic || [];
-    return topics
-        .map(topic => Object.keys(topicClusters).find(cluster => topicClusters[cluster].topics.includes(topic)))
-        .filter(Boolean);
+    return EcoData.getArtworkClusters(artwork, topicClusters);
 }
 
 function getMetricLabel() {
@@ -77,9 +52,7 @@ function updateChartTitles() {
 }
 
 function normalizeValue(count, population) {
-    if (selectedMetric !== 'perCapita') return count;
-    if (!population || population <= 0) return null;
-    return (count / population) * 1000000;
+    return EcoData.normalizePerCapita(count, population, selectedMetric);
 }
 
 function sumPopulation(countries) {
@@ -93,7 +66,7 @@ function refreshCountryListVisibility() {
   const countrySelect = document.getElementById('countrySelect');
   if (!countrySelect) return;
 
-  const query = normalizeStr(document.getElementById('countrySearch')?.value?.trim() || "");
+  const query = normalizeText(document.getElementById('countrySearch')?.value?.trim() || "");
 
   // aktuell gewählte Kontinente (inkl. "all")
   const continents = Array.from(document.getElementById('continentSelect').selectedOptions)
@@ -116,7 +89,7 @@ function refreshCountryListVisibility() {
       continents.includes('all') ||
       continents.includes(continent);
 
-    const matchesQuery = query === "" || normalizeStr(opt.text).includes(query);
+    const matchesQuery = query === "" || normalizeText(opt.text).includes(query);
 
     const visible = matchesContinent && matchesQuery;
 
@@ -140,26 +113,7 @@ function setupCountrySearch() {
 // Daten laden
 async function loadData() {
     try {
-        // JSON-Dateien aus dem 'data'-Ordner laden
-        artworks = await fetch('data/artwork-data.json').then(res => {
-            if (!res.ok) throw new Error('Failed to load artwork-data.json');
-            return res.json();
-        });
-
-        topicClusters = await fetch('data/topicClusters.json').then(res => {
-            if (!res.ok) throw new Error('Failed to load topicClusters.json');
-            return res.json();
-        });
-
-        continentMapping = await fetch('data/continentMapping.json').then(res => {
-            if (!res.ok) throw new Error('Failed to load continentMapping.json');
-            return res.json();
-        });
-
-        countryPopulation = await fetch('data/countryPopulation.json').then(res => {
-            if (!res.ok) throw new Error('Failed to load countryPopulation.json');
-            return res.json();
-        });
+        ({ artworkData: artworks, topicClusters, continentMapping, countryPopulation } = await loadSharedData());
 
         console.log("JSON files loaded successfully");
         initializeFilters();
@@ -289,14 +243,6 @@ function updateCharts() {
 }
 
 // Hilfsfunktion für Farben
-function getClusterColors() {
-    let clusterColors = {};
-    Object.keys(topicClusters).forEach(cluster => {
-        clusterColors[cluster] = topicClusters[cluster].color;
-    });
-    return clusterColors;
-}
-
 // Zentrales Plotly-Layout für alle Diagramme
 const plotlyLayout = {
     barmode: 'stack',
@@ -342,7 +288,7 @@ function filterArtworks(artworks) {
 // Themencluster nach Land
 function updateCountryChart() {
     let countryData = {};
-    let clusterColors = getClusterColors();
+    let clusterColors = EcoData.getClusterColors(topicClusters);
     let filteredArtworks = filterArtworks(artworks);
 
     filteredArtworks.forEach(artwork => {
@@ -374,15 +320,15 @@ function updateCountryChart() {
 // Themencluster über die Zeit (Liniendiagramm)
 function updateTopicClustersOverTime() {
     let timeData = {};
-    let clusterColors = getClusterColors();
+    let clusterColors = EcoData.getClusterColors(topicClusters);
     let filteredArtworks = filterArtworks(artworks);
     let filteredCountries = new Set(filteredArtworks.map(artwork => getCountryFromLocation(artwork.properties.location)));
     let populationBase = sumPopulation(filteredCountries);
 
     // Jahre sammeln & Themen zuordnen
     filteredArtworks.forEach(artwork => {
-        let year = parseInt(artwork.properties.year, 10);
-        if (isNaN(year)) return;
+        let year = parseYear(artwork.properties.year);
+        if (year === null) return;
 
         let cluster = getArtworkClusters(artwork);
 
@@ -436,7 +382,7 @@ function updateTopicClustersOverTime() {
 // Themencluster nach Kontinent
 function updateTopicsByContinent() {
     let continentData = {};
-    let clusterColors = getClusterColors();
+    let clusterColors = EcoData.getClusterColors(topicClusters);
     let filteredArtworks = filterArtworks(artworks);
 
     filteredArtworks.forEach(artwork => {
@@ -474,7 +420,7 @@ function updateTopicsByContinent() {
 function updateCoOccurrenceNetwork() {
     let nodes = [];
     let edges = [];
-    let clusterColors = getClusterColors();
+    let clusterColors = EcoData.getClusterColors(topicClusters);
     let filteredArtworks = filterArtworks(artworks);
     let nodeSet = new Set();
 

--- a/assets/js/globe.js
+++ b/assets/js/globe.js
@@ -5,15 +5,11 @@ let topicClusters = {};
 let continentMapping = {};
 let countryPopulation = {};
 let enrichedFeatures = [];
-
-const COUNTRY_ALIASES = {
-    "DRC (Africa leg)": "Democratic Republic of the Congo",
-    "Dead Sea region (Israel/Jordan Rift)": "Israel",
-    "Dead Sea region (Jordan/Israel)": "Israel",
-    "Tropical regions": "Other",
-    "Various exhibitions": "Other",
-    "United States Minor Outlying Islands": "Other"
-};
+const {
+    loadSharedData,
+    normalizeText,
+    parseYear
+} = EcoData;
 
 const globe = new mapboxgl.Map({
     container: 'globeMap',
@@ -27,14 +23,6 @@ const globe = new mapboxgl.Map({
 globe.addControl(new mapboxgl.NavigationControl(), 'bottom-right');
 globe.addControl(new mapboxgl.AttributionControl({ compact: true }), 'bottom-left');
 
-function normalizeText(value) {
-    return (value || '')
-        .toString()
-        .normalize('NFD')
-        .replace(/\p{Diacritic}/gu, '')
-        .toLowerCase();
-}
-
 function escapeHtml(value) {
     return (value || '')
         .toString()
@@ -45,32 +33,21 @@ function escapeHtml(value) {
         .replace(/'/g, '&#039;');
 }
 
-function getCountryFromLocation(location) {
-    const rawLocation = (location || '').trim();
-    if (COUNTRY_ALIASES[rawLocation]) return COUNTRY_ALIASES[rawLocation];
-    if (continentMapping[rawLocation] || countryPopulation[rawLocation]) return rawLocation;
 
-    const lastPart = rawLocation.split(',').pop().trim();
-    return COUNTRY_ALIASES[lastPart] || lastPart || 'Other';
+function getCountryFromLocation(location) {
+    return EcoData.getCountryFromLocation(location, continentMapping, countryPopulation);
 }
 
 function getContinentForCountry(country) {
-    return continentMapping[country] || continentMapping[country?.toLowerCase()] || 'Other';
+    return EcoData.getContinentForCountry(country, continentMapping);
 }
 
 function getArtworkClusters(feature) {
-    const topics = feature.properties?.tags?.topic || [];
-    return topics
-        .map(topic => Object.keys(topicClusters).find(cluster => topicClusters[cluster].topics.includes(topic)))
-        .filter(Boolean);
-}
-
-function getMainCluster(feature) {
-    return getArtworkClusters(feature)[0] || 'Uncategorized';
+    return EcoData.getArtworkClusters(feature, topicClusters);
 }
 
 function getClusterColor(cluster) {
-    return topicClusters[cluster]?.color || '#9ca3af';
+    return EcoData.getClusterColor(cluster, topicClusters);
 }
 
 function getMetricMode() {
@@ -82,9 +59,7 @@ function getMetricLabel() {
 }
 
 function normalizeValue(count, population) {
-    if (getMetricMode() !== 'perCapita') return count;
-    if (!population || population <= 0) return 0;
-    return (count / population) * 1000000;
+    return EcoData.normalizePerCapita(count, population, getMetricMode()) ?? 0;
 }
 
 function isValidPoint(feature) {
@@ -93,22 +68,7 @@ function isValidPoint(feature) {
 }
 
 function enrichFeature(feature) {
-    const country = getCountryFromLocation(feature.properties?.location);
-    const continent = getContinentForCountry(country);
-    const clusters = getArtworkClusters(feature);
-    const mainCluster = clusters[0] || 'Uncategorized';
-
-    return {
-        ...feature,
-        properties: {
-            ...feature.properties,
-            country,
-            continent,
-            clusters,
-            mainCluster,
-            mainClusterColor: getClusterColor(mainCluster)
-        }
-    };
+    return EcoData.enrichArtwork(feature, { topicClusters, continentMapping, countryPopulation });
 }
 
 function getFilteredFeatures() {
@@ -119,14 +79,14 @@ function getFilteredFeatures() {
 
     return enrichedFeatures.filter(feature => {
         const props = feature.properties || {};
-        const year = parseInt(props.year, 10);
+        const year = parseYear(props.year);
         const text = normalizeText(`${props.title} ${props.artist} ${props.location} ${props.description}`);
 
         if (!isValidPoint(feature)) return false;
         if (query && !text.includes(query)) return false;
         if (cluster && !(props.clusters || []).includes(cluster)) return false;
-        if (!Number.isNaN(fromYear) && year < fromYear) return false;
-        if (!Number.isNaN(toYear) && year > toYear) return false;
+        if (!Number.isNaN(fromYear) && year !== null && year < fromYear) return false;
+        if (!Number.isNaN(toYear) && year !== null && year > toYear) return false;
         return true;
     });
 }
@@ -353,17 +313,7 @@ function addGlobeLayers() {
 }
 
 async function loadGlobeData() {
-    const [artworkResponse, topicResponse, continentResponse, populationResponse] = await Promise.all([
-        fetch('data/artwork-data.json'),
-        fetch('data/topicClusters.json'),
-        fetch('data/continentMapping.json'),
-        fetch('data/countryPopulation.json')
-    ]);
-
-    artworkData = await artworkResponse.json();
-    topicClusters = await topicResponse.json();
-    continentMapping = await continentResponse.json();
-    countryPopulation = await populationResponse.json();
+    ({ artworkData, topicClusters, continentMapping, countryPopulation } = await loadSharedData());
     enrichedFeatures = (artworkData.features || []).map(enrichFeature);
 
     populateClusterFilter();

--- a/assets/js/shared-data.js
+++ b/assets/js/shared-data.js
@@ -1,0 +1,126 @@
+const EcoData = (() => {
+    const DATA_PATHS = {
+        artworkData: 'data/artwork-data.json',
+        topicClusters: 'data/topicClusters.json',
+        continentMapping: 'data/continentMapping.json',
+        countryPopulation: 'data/countryPopulation.json'
+    };
+
+    const COUNTRY_ALIASES = {
+        "DRC (Africa leg)": "Democratic Republic of the Congo",
+        "Dead Sea region (Israel/Jordan Rift)": "Israel",
+        "Dead Sea region (Jordan/Israel)": "Israel",
+        "Tropical regions": "Other",
+        "Various exhibitions": "Other",
+        "United States Minor Outlying Islands": "Other"
+    };
+
+    async function fetchJson(path, label) {
+        const response = await fetch(path);
+        if (!response.ok) throw new Error(`Failed to load ${label}`);
+        return response.json();
+    }
+
+    async function loadSharedData() {
+        const [artworkData, topicClusters, continentMapping, countryPopulation] = await Promise.all([
+            fetchJson(DATA_PATHS.artworkData, 'artwork-data.json'),
+            fetchJson(DATA_PATHS.topicClusters, 'topicClusters.json'),
+            fetchJson(DATA_PATHS.continentMapping, 'continentMapping.json'),
+            fetchJson(DATA_PATHS.countryPopulation, 'countryPopulation.json')
+        ]);
+
+        return {
+            artworkData,
+            topicClusters,
+            continentMapping,
+            countryPopulation
+        };
+    }
+
+    function normalizeText(value) {
+        return (value || '')
+            .toString()
+            .normalize('NFD')
+            .replace(/\p{Diacritic}/gu, '')
+            .toLowerCase();
+    }
+
+    function getCountryFromLocation(location, continentMapping = {}, countryPopulation = {}) {
+        const rawLocation = (location || '').trim();
+        if (COUNTRY_ALIASES[rawLocation]) return COUNTRY_ALIASES[rawLocation];
+        if (continentMapping[rawLocation] || countryPopulation[rawLocation]) return rawLocation;
+
+        const lastPart = rawLocation.split(',').pop().trim();
+        return COUNTRY_ALIASES[lastPart] || lastPart || 'Other';
+    }
+
+    function getContinentForCountry(country, continentMapping = {}) {
+        return continentMapping[country] || continentMapping[country?.toLowerCase()] || 'Other';
+    }
+
+    function getArtworkClusters(artwork, topicClusters = {}) {
+        const topics = artwork.properties?.tags?.topic || [];
+        return topics
+            .map(topic => Object.keys(topicClusters).find(cluster => topicClusters[cluster].topics.includes(topic)))
+            .filter(Boolean);
+    }
+
+    function getMainCluster(artwork, topicClusters = {}) {
+        return getArtworkClusters(artwork, topicClusters)[0] || 'Uncategorized';
+    }
+
+    function getClusterColor(cluster, topicClusters = {}) {
+        return topicClusters[cluster]?.color || '#9ca3af';
+    }
+
+    function getClusterColors(topicClusters = {}) {
+        return Object.fromEntries(
+            Object.entries(topicClusters).map(([cluster, data]) => [cluster, data.color])
+        );
+    }
+
+    function parseYear(value) {
+        const year = parseInt(value, 10);
+        return Number.isNaN(year) ? null : year;
+    }
+
+    function normalizePerCapita(count, population, metricMode) {
+        if (metricMode !== 'perCapita') return count;
+        if (!population || population <= 0) return null;
+        return (count / population) * 1000000;
+    }
+
+    function enrichArtwork(artwork, { topicClusters = {}, continentMapping = {}, countryPopulation = {} } = {}) {
+        const country = getCountryFromLocation(artwork.properties?.location, continentMapping, countryPopulation);
+        const continent = getContinentForCountry(country, continentMapping);
+        const clusters = getArtworkClusters(artwork, topicClusters);
+        const mainCluster = clusters[0] || 'Uncategorized';
+
+        return {
+            ...artwork,
+            properties: {
+                ...artwork.properties,
+                country,
+                continent,
+                clusters,
+                mainCluster,
+                mainClusterColor: getClusterColor(mainCluster, topicClusters)
+            }
+        };
+    }
+
+    return {
+        COUNTRY_ALIASES,
+        loadSharedData,
+        normalizeText,
+        getCountryFromLocation,
+        getContinentForCountry,
+        getArtworkClusters,
+        getMainCluster,
+        getClusterColor,
+        getClusterColors,
+        parseYear,
+        normalizePerCapita,
+        enrichArtwork
+    };
+})();

--- a/data-analysis.html
+++ b/data-analysis.html
@@ -72,6 +72,7 @@
         </div>
     </main>
 
+    <script src="assets/js/shared-data.js"></script>
     <script src="assets/js/data-analysis.js"></script>
 </body>
 </html>

--- a/globe.html
+++ b/globe.html
@@ -95,6 +95,7 @@
     </main>
 
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <script src="assets/js/shared-data.js"></script>
     <script src="assets/js/globe.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
     </main>
 
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <script src="assets/js/shared-data.js"></script>
     <script src="assets/js/globe.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Reduce duplicated data and helper logic by centralizing shared operations for the Explore and Data Analysis pages to make maintenance easier while preserving existing behavior.

### Description
- Add `assets/js/shared-data.js` which exposes `EcoData` helpers including `loadSharedData`, `normalizeText`, `getCountryFromLocation`, `getContinentForCountry`, `getArtworkClusters`, `getMainCluster`, `getClusterColor`, `getClusterColors`, `parseYear`, `normalizePerCapita`, and `enrichArtwork` to handle JSON loading, normalization, mapping, color lookup, year parsing, per-capita normalization and artwork enrichment.
- Update `assets/js/globe.js` to consume `EcoData` for loading the four JSON files and for normalization, country/continent/cluster lookups, year parsing, per-capita normalization and enrichment while keeping Mapbox rendering, layer/source setup, popups, UI wiring, filtering and ranking logic page-specific.
- Update `assets/js/data-analysis.js` to consume `EcoData` for JSON loading and the same shared helpers while keeping filter UI, Plotly traces, chart rendering and vis-network rendering page-specific.
- Update `index.html` and `data-analysis.html` to load `assets/js/shared-data.js` before their page-specific scripts and preserve existing JSON structures and visible design.

### Testing
- Ran `node --check assets/js/shared-data.js`, `node --check assets/js/globe.js`, and `node --check assets/js/data-analysis.js`, and all checks completed successfully.
- Ran a basic HTML parser check on `index.html` and `data-analysis.html`, and both files parsed successfully.
- Functions moved into `EcoData`: `loadSharedData`, `normalizeText`, `getCountryFromLocation`, `getContinentForCountry`, `getArtworkClusters`, `getMainCluster`, `getClusterColor`, `getClusterColors`, `parseYear`, `normalizePerCapita`, and `enrichArtwork`.
- Behavior intentionally left page-specific: Mapbox initialization, sources/layers, popups, globe filtering/aggregation/ranking in `assets/js/globe.js`, and filter wiring, Plotly trace construction, chart layout choices and co-occurrence network rendering in `assets/js/data-analysis.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bbc88602c8330b7030e1aa1602224)