### PR TITLE
Exclude very-small-population countries from per-capita country charts and rankings

### DIFF
--- a/assets/js/data-analysis.js
+++ b/assets/js/data-analysis.js
@@ -49,10 +49,19 @@ function updateChartTitles() {
     document.getElementById('topicClustersOverTimeTitle').textContent = perCapita
         ? 'Topic Clusters per 1M People Over Time'
         : 'Change of Topic Clusters Over Time';
+
+    const countryChartPopulationNote = document.getElementById('countryChartPopulationNote');
+    if (countryChartPopulationNote) {
+        countryChartPopulationNote.classList.toggle('hidden', !perCapita);
+    }
 }
 
 function normalizeValue(count, population) {
     return EcoData.normalizePerCapita(count, population, selectedMetric);
+}
+
+function shouldIncludeCountryInChart(country) {
+    return selectedMetric !== 'perCapita' || !EcoData.isSmallPopulationBase(countryPopulation[country]);
 }
 
 function sumPopulation(countries) {
@@ -302,9 +311,11 @@ function updateCountryChart() {
         });
     });
 
+    const visibleCountries = Object.keys(countryData).filter(shouldIncludeCountryInChart);
+
     let traces = Object.keys(clusterColors).map(cluster => ({
-        x: Object.keys(countryData),
-        y: Object.keys(countryData).map(country => normalizeValue(countryData[country][cluster] || 0, countryPopulation[country])),
+        x: visibleCountries,
+        y: visibleCountries.map(country => normalizeValue(countryData[country][cluster] || 0, countryPopulation[country])),
         name: cluster,
         type: 'bar',
         marker: { color: clusterColors[cluster] },

--- a/assets/js/globe.js
+++ b/assets/js/globe.js
@@ -185,15 +185,24 @@ function renderRanking(containerId, items) {
     }).join('');
 }
 
+function getCountryRankingData(countryData) {
+    if (getMetricMode() !== 'perCapita') return countryData;
+
+    return Object.fromEntries(
+        Object.entries(countryData).filter(([, item]) => !EcoData.isSmallPopulationBase(item.population))
+    );
+}
+
 function updateGlobe() {
     const filtered = getFilteredFeatures();
     const countryData = aggregateByCountry(filtered);
     const continentData = aggregateByContinent(filtered);
+    const countryRankingData = getCountryRankingData(countryData);
     const displayFeatures = enrichMetricValues(filtered, countryData);
 
     document.getElementById('globeArtworkCount').textContent = filtered.length;
     document.getElementById('globeCountryCount').textContent = Object.keys(countryData).length;
-    renderRanking('globeCountryRanking', countryData);
+    renderRanking('globeCountryRanking', countryRankingData);
     renderRanking('globeContinentRanking', continentData);
 
     const source = globe.getSource('globeArtworks');

--- a/assets/js/shared-data.js
+++ b/assets/js/shared-data.js
@@ -6,6 +6,8 @@ const EcoData = (() => {
         countryPopulation: 'data/countryPopulation.json'
     };
 
+    const MIN_POPULATION_FOR_COUNTRY_PER_CAPITA = 1000000;
+
     const COUNTRY_ALIASES = {
         "DRC (Africa leg)": "Democratic Republic of the Congo",
         "Dead Sea region (Israel/Jordan Rift)": "Israel",
@@ -90,6 +92,10 @@ const EcoData = (() => {
         return (count / population) * 1000000;
     }
 
+    function isSmallPopulationBase(population) {
+        return !population || population < MIN_POPULATION_FOR_COUNTRY_PER_CAPITA;
+    }
+
     function enrichArtwork(artwork, { topicClusters = {}, continentMapping = {}, countryPopulation = {} } = {}) {
         const country = getCountryFromLocation(artwork.properties?.location, continentMapping, countryPopulation);
         const continent = getContinentForCountry(country, continentMapping);
@@ -111,6 +117,7 @@ const EcoData = (() => {
 
     return {
         COUNTRY_ALIASES,
+        MIN_POPULATION_FOR_COUNTRY_PER_CAPITA,
         loadSharedData,
         normalizeText,
         getCountryFromLocation,
@@ -121,6 +128,7 @@ const EcoData = (() => {
         getClusterColors,
         parseYear,
         normalizePerCapita,
+        isSmallPopulationBase,
         enrichArtwork
     };
 })();

--- a/data-analysis.html
+++ b/data-analysis.html
@@ -51,7 +51,8 @@
                 </section>
 
                 <section id="topics-by-country" class="mb-8 chart-container">
-                    <h3 id="countryChartTitle" class="text-2xl font-semibold mb-4">Number of Topic Clusters by Country</h3>
+                    <h3 id="countryChartTitle" class="text-2xl font-semibold mb-2">Number of Topic Clusters by Country</h3>
+                    <p id="countryChartPopulationNote" class="text-sm opacity-75 mb-4 hidden">Countries/territories below 1M population are excluded from this per-capita chart to keep the visualization readable.</p>
                     <div class="w-[800px]">
                         <div id="countryChart" class="plotly-chart"></div>
                     </div>


### PR DESCRIPTION
### Motivation
- Per-capita mode can be dominated by very small-population countries (e.g., Greenland), making country charts unreadable.
- Provide a simple, reviewable rule to keep per-capita visualizations readable while not changing underlying data or JSON structure.

### Description
- Add a shared constant `MIN_POPULATION_FOR_COUNTRY_PER_CAPITA = 1000000` and helper `isSmallPopulationBase(population)` to `assets/js/shared-data.js` (exposed on `EcoData`).
- In `assets/js/data-analysis.js` exclude countries below the threshold from the Data Analysis country chart when `selectedMetric === 'perCapita'` and show a small explanatory note added to `data-analysis.html` toggled by `updateChartTitles()`; total mode is unchanged.
- In `assets/js/globe.js` exclude small-population countries from the Explore country ranking when the globe metric is `perCapita` while keeping continent rankings and the underlying aggregation unchanged.
- The change only hides countries from the visualizations; no countries are removed from the JSON and no JSON structure changes were made.

### Testing
- Ran `node --check assets/js/shared-data.js` and it succeeded.
- Ran `node --check assets/js/data-analysis.js` and it succeeded.
- Ran `node --check assets/js/globe.js` and it succeeded.
- Ran a basic HTML parse check on `data-analysis.html` using Python's `HTMLParser` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc828f62c833082e4dc8d2f654c21)