### PR TITLE
Show artwork thumbnails in Explore/Globe popups

### DIFF
--- a/assets/js/globe.js
+++ b/assets/js/globe.js
@@ -33,6 +33,15 @@ function escapeHtml(value) {
         .replace(/'/g, '&#039;');
 }
 
+function getThumbnailHtml(thumbnail) {
+    const thumbnailUrl = (thumbnail || '').toString().trim();
+
+    if (!/^https?:\/\/[^\s"'<>]+$/i.test(thumbnailUrl)) {
+        return '';
+    }
+
+    return `<img class="globe-popup-thumbnail" src="${escapeHtml(thumbnailUrl)}" alt="" loading="lazy">`;
+}
 
 function getCountryFromLocation(location) {
     return EcoData.getCountryFromLocation(location, continentMapping, countryPopulation);
@@ -296,11 +305,13 @@ function addGlobeLayers() {
         const coordinates = feature.geometry.coordinates.slice();
         const metricValue = Number(props.countryMetric || 0);
         const metricDisplay = getMetricMode() === 'perCapita' ? metricValue.toFixed(3) : metricValue.toFixed(0);
+        const thumbnailHtml = getThumbnailHtml(props.thumbnail);
 
         new mapboxgl.Popup({ maxWidth: '320px' })
             .setLngLat(coordinates)
             .setHTML(`
                 <div class="globe-popup">
+                    ${thumbnailHtml}
                     <h3>${escapeHtml(props.title || 'Untitled')}</h3>
                     <p><strong>Artist:</strong> ${escapeHtml(props.artist || 'Unknown')}</p>
                     <p><strong>Location:</strong> ${escapeHtml(props.location || 'Unknown')}</p>

--- a/style.css
+++ b/style.css
@@ -140,6 +140,15 @@
   color: #111827;
 }
 
+.globe-popup-thumbnail {
+  display: block;
+  width: 100%;
+  max-height: 160px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  margin: 0 0 0.75rem;
+}
+
 .globe-popup h3 {
   margin: 0 0 0.5rem;
   font-weight: 700;


### PR DESCRIPTION
### Motivation
- Improve the Globe/Explore popup UX by showing an artwork thumbnail when `props.thumbnail` contains a valid URL while keeping the existing popup fields and layout.
- Keep the change narrowly scoped to popup rendering and styling only, without changing data structures or adding libraries.

### Description
- Added a helper `getThumbnailHtml(thumbnail)` in `assets/js/globe.js` that trims the input, validates it against a simple `https?://` regex, and returns an escaped `<img>` tag or an empty string when invalid.  
- Injected the produced `thumbnailHtml` above the existing title in the Mapbox popup markup so title, artist, location, cluster and country metric remain unchanged.  
- Added lightweight CSS in `style.css` for `.globe-popup-thumbnail` to make the image full width, `max-height: 160px`, `object-fit: cover`, rounded corners and a small bottom margin.

### Testing
- Ran `node --check assets/js/globe.js` to verify the modified JS is syntactically valid, which succeeded.  
- Performed a basic HTML/CSS sanity check by confirming relevant `.html`/`.css` files are present and non-empty, which succeeded.  

Files changed: `assets/js/globe.js`, `style.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bcefd097c8330bc81e752f613e7ae)