### PR TITLE
Fix country per-capita chart scaling

### DIFF
--- a/assets/js/data-analysis.js
+++ b/assets/js/data-analysis.js
@@ -313,18 +313,34 @@ function updateCountryChart() {
 
     const visibleCountries = Object.keys(countryData).filter(shouldIncludeCountryInChart);
 
+    let maxDisplayedStackValue = 0;
+    const countryStackTotals = Object.fromEntries(visibleCountries.map(country => [country, 0]));
+
     let traces = Object.keys(clusterColors).map(cluster => ({
         x: visibleCountries,
-        y: visibleCountries.map(country => normalizeValue(countryData[country][cluster] || 0, countryPopulation[country])),
+        y: visibleCountries.map(country => {
+            const value = normalizeValue(countryData[country][cluster] || 0, countryPopulation[country]);
+            countryStackTotals[country] += value;
+            return value;
+        }),
         name: cluster,
         type: 'bar',
         marker: { color: clusterColors[cluster] },
         hovertemplate: `%{x}<br>${cluster}: %{y:.3f}<extra></extra>`
     }));
 
+    if (selectedMetric === 'perCapita') {
+        maxDisplayedStackValue = Math.max(0, ...Object.values(countryStackTotals));
+    }
+
+    const yaxis = { ...plotlyLayout.yaxis, title: getMetricLabel() };
+    if (selectedMetric === 'perCapita') {
+        yaxis.range = [0, maxDisplayedStackValue > 0 ? maxDisplayedStackValue * 1.2 : 1];
+    }
+
     Plotly.newPlot('countryChart', traces, {
         ...plotlyLayout,
-        yaxis: { ...plotlyLayout.yaxis, title: getMetricLabel() }
+        yaxis
     });
 }
 


### PR DESCRIPTION
### Motivation
- The country chart in per-capita mode kept a large fixed/auto y-axis so bars for visible countries (after excluding populations < 1M) appeared very small and the chart was hard to read.
- The goal is to make the country per-capita chart visually readable while preserving existing small-population filtering and leaving continent and total-mode behavior unchanged.

### Description
- In `assets/js/data-analysis.js` the country chart rendering now computes stacked totals only for `visibleCountries` (countries remaining after `shouldIncludeCountryInChart`).
- When `selectedMetric === 'perCapita'` the code sets the chart y-axis range to `[0, maxDisplayedStackValue * 1.2]` where `maxDisplayedStackValue` is the maximum stacked value across visible countries, with a fallback of `1` if there are no displayed values.
- The change only affects the country chart per-capita mode and preserves the JSON structure, the small-population filtering logic, continent charts, and total-mode behavior.
- The per-capita explanatory note remains tied to the per-capita toggle and is still shown/hidden as before.

### Testing
- Ran `node --check assets/js/data-analysis.js` which returned no syntax errors.
- Visual/manual verification recommended in the browser to confirm improved y-axis scaling and that the population-exclusion note is visible in per-capita mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bd19879c88330b98859c6d98f75ae)