### PR TITLE
Add thumbnail URLs for multiple artworks in artwork-data.json

### DIFF
--- a/data/artwork-data.json
+++ b/data/artwork-data.json
@@ -366,7 +366,7 @@
         ]
       },
       "url": "https://artsandculture.google.com/asset/7000-oaks-joseph-beuys/QwG4E0M8Qh4V0A",
-      "thumbnail": ""
+      "thumbnail": "https://commons.wikimedia.org/wiki/Special:FilePath/FridericianumBeuys_kasselgalerie_de.jpg"
     }
   },
   {
@@ -415,7 +415,7 @@
         ]
       },
       "url": "https://artsandculture.google.com/entity/joseph-beuys/m01m4t",
-      "thumbnail": ""
+      "thumbnail": "https://upload.wikimedia.org/wikipedia/en/thumb/e/e3/I_Like_America_and_America_Likes_Me.jpg/330px-I_Like_America_and_America_Likes_Me.jpg"
     }
   },
   {
@@ -565,7 +565,7 @@
         "artform": ["Literature"]
       },
       "url": "https://www.penguinrandomhouse.com/books/576941/the-history-of-bees-by-maja-lunde/",
-      "thumbnail": ""
+      "thumbnail": "https://books.google.com/books/content?id=9BRpDQAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
     }
   },
   {
@@ -583,7 +583,7 @@
         "artform": ["Literature"]
       },
       "url": "https://www.penguinrandomhouse.com/books/607026/the-end-of-the-ocean-by-maja-lunde/",
-      "thumbnail": ""
+      "thumbnail": "https://books.google.com/books/content?id=QKJfDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
     }
   },
   {
@@ -804,7 +804,7 @@
         "artform": ["Installation", "Public Art"]
       },
       "url": "https://artsandculture.google.com/asset/carbon-sink-chris-drury/IgE7lwKrV7-Wzw",
-      "thumbnail": ""
+      "thumbnail": "https://chrisdrury.co.uk/wp-content/uploads/2022/03/wo_carbon_sink.jpg"
     }
   },
   {
@@ -840,7 +840,7 @@
         "artform": ["Photography"]
       },
       "url": "https://artsandculture.google.com/asset/beauty-shop-lori-nix/qwHXLxnktiOhqg",
-      "thumbnail": ""
+      "thumbnail": "https://images.squarespace-cdn.com/content/v1/55d77558e4b05e2874c32d03/1440186236158-77KJDMFM2LNL49G83DHJ/Beauty%2BShop.jpg"
     }
   },
   {
@@ -876,7 +876,7 @@
         "artform": ["Photography"]
       },
       "url": "https://artsandculture.google.com/asset/night-in-qaanaaq-greenland-sebastian-copeland/zwGoIpb11ifBUw",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/01/S_Copeland_NightInQaanaaq.jpg"
     }
   },
   {
@@ -894,7 +894,7 @@
         "artform": ["Painting"]
       },
       "url": "https://artsandculture.google.com/asset/growing-pains-laura-ball/pwF9FZMMV73X7g",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2015/12/L_Ball_GrowingPains.jpg"
     }
   },
   {
@@ -930,7 +930,7 @@
         "artform": ["Design", "Architecture"]
       },
       "url": "https://artsandculture.google.com/asset/cricket-shelter-modular-edible-insect-farm-mitchell-joachim-and-terreform-one/LwETzcTuElqeGQ",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/07/1-Mitchell-Joachim-and-Terreform-ONE-cricket_sky_terreform_AAA1_slider.jpg"
     }
   },
   {
@@ -1057,7 +1057,7 @@
         "artform": ["Photography"]
       },
       "url": "https://artsandculture.google.com/story/art-with-an-ocean-view-art-works-for-change/iwVRP5j8b2P7KA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/01/S_Copeland_IcebergXVIII.jpg"
     }
   },
   {
@@ -1783,7 +1783,7 @@
           ]
         },
         "url": "https://www.atlasobscura.com/places/bordalo-ii-plastic-mero",
-        "thumbnail": ""
+        "thumbnail": "https://commons.wikimedia.org/wiki/Special:FilePath/Funchal%2C%20Pra%C3%A7a%20CR7%20-%20Plastic%20Mero%20by%20Artur%20Bordalo%20a.k.a.%20Bordalo%20II.jpg"
       }
     },
     {
@@ -2092,7 +2092,7 @@
                 "cluster": ["Urban Issues", "Resource Depletion"],
                 "artform": ["Music"]
             },
-            "thumbnail": ""
+            "thumbnail": "https://upload.wikimedia.org/wikipedia/en/thumb/5/59/Big_Yellow_Taxi_by_Joni_Mitchell_1970_Canadian_vinyl.png/250px-Big_Yellow_Taxi_by_Joni_Mitchell_1970_Canadian_vinyl.png"
         }
     },
     {
@@ -3543,7 +3543,7 @@
             "artform": ["Installation", "Public Art", "Community"]
             },
             "url": "https://www.iisd.org/articles/news/suncasa-turning-trash-treasures-along-jukskei-river-johannesburg",
-            "thumbnail": ""
+            "thumbnail": "https://www.hanneliecoetzee.com/wp-content/uploads/2025/02/130425-Art-and-litter-trap-MAP-SUNCASA-STRIP-v3-FIN.jpg"
             }
             },
             {
@@ -3561,7 +3561,7 @@
             "artform": ["Sculpture", "Installation", "Eco-Art"]
             },
             "url": "https://en.wikipedia.org/wiki/Romuald_Hazoum%C3%A8",
-            "thumbnail": ""
+            "thumbnail": "https://www.octobergallery.co.uk/website_safezone/images/figures/RH005-image.jpg"
             }
             },
             {
@@ -3615,7 +3615,7 @@
             "artform": ["Sculpture", "Eco-Art"]
             },
             "url": "https://indigoarts.com/galleries/recycled-flip-flop-sculptures-kenya",
-            "thumbnail": ""
+            "thumbnail": "https://indigoarts.com/sites/default/files/styles/medium_sidespace/public/flip-lion-med-1.jpg?itok=YhDb73zy"
             }
             },
             {


### PR DESCRIPTION
### Motivation
- Ensure artworks have representative thumbnails for UI previews by populating previously empty `thumbnail` fields in `data/artwork-data.json`.

### Description
- Replaced empty `thumbnail` values with valid image URLs for multiple `Feature` entries in `data/artwork-data.json`.
- Updated entries span installations, books, photographs, sculptures, and music records to improve front-end previews and map markers.
- Changes are limited to the JSON data file and do not modify application code or schemas.

### Testing
- Validated JSON syntax using `jq` to ensure the file parses without errors.
- Ran the project's linter/format check to confirm formatting consistency.
- No unit tests were changed or added as part of this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bdac9251883308682710654bb7844)