### PR TITLE
Improve Explore popup cards (description excerpts, thumbnails, styling)

### DIFF
--- a/assets/js/globe.js
+++ b/assets/js/globe.js
@@ -40,7 +40,33 @@ function getThumbnailHtml(thumbnail) {
         return '';
     }
 
-    return `<img class="globe-popup-thumbnail" src="${escapeHtml(thumbnailUrl)}" alt="" loading="lazy">`;
+    return `<img class="globe-popup-thumbnail" src="${escapeHtml(thumbnailUrl)}" alt="" loading="lazy" decoding="async">`;
+}
+
+function getDescriptionExcerpt(description, maxLength = 180) {
+    const normalizedDescription = (description || '').toString().trim().replace(/\s+/g, ' ');
+
+    if (!normalizedDescription) {
+        return '';
+    }
+
+    if (normalizedDescription.length <= maxLength) {
+        return normalizedDescription;
+    }
+
+    const truncated = normalizedDescription.slice(0, maxLength).trimEnd();
+    const lastSpaceIndex = truncated.lastIndexOf(' ');
+    const excerpt = lastSpaceIndex > Math.floor(maxLength * 0.6)
+        ? truncated.slice(0, lastSpaceIndex).trimEnd()
+        : truncated;
+
+    return `${excerpt}…`;
+}
+
+function getValidUrl(value) {
+    const url = (value || '').toString().trim();
+
+    return /^https?:\/\/[^\s"'<>]+$/i.test(url) ? url : '';
 }
 
 function getCountryFromLocation(location) {
@@ -315,6 +341,15 @@ function addGlobeLayers() {
         const metricValue = Number(props.countryMetric || 0);
         const metricDisplay = getMetricMode() === 'perCapita' ? metricValue.toFixed(3) : metricValue.toFixed(0);
         const thumbnailHtml = getThumbnailHtml(props.thumbnail);
+        const descriptionExcerpt = getDescriptionExcerpt(props.description);
+        const descriptionHtml = descriptionExcerpt
+            ? `<p class="globe-popup-description">${escapeHtml(descriptionExcerpt)}</p>`
+            : '';
+        const artistText = props.year ? `${props.artist || 'Unknown'}, ${props.year}` : (props.artist || 'Unknown');
+        const moreInfoUrl = getValidUrl(props.url);
+        const moreInfoHtml = moreInfoUrl
+            ? `<a class="globe-popup-link" href="${escapeHtml(moreInfoUrl)}" target="_blank" rel="noopener noreferrer">More information</a>`
+            : '';
 
         new mapboxgl.Popup({ maxWidth: '320px' })
             .setLngLat(coordinates)
@@ -322,10 +357,14 @@ function addGlobeLayers() {
                 <div class="globe-popup">
                     ${thumbnailHtml}
                     <h3>${escapeHtml(props.title || 'Untitled')}</h3>
-                    <p><strong>Artist:</strong> ${escapeHtml(props.artist || 'Unknown')}</p>
-                    <p><strong>Location:</strong> ${escapeHtml(props.location || 'Unknown')}</p>
-                    <p><strong>Cluster:</strong> ${escapeHtml(props.mainCluster || 'Uncategorized')}</p>
-                    <p><strong>Country metric:</strong> ${metricDisplay} ${getMetricLabel()}</p>
+                    <div class="globe-popup-primary-meta">${escapeHtml(artistText)}</div>
+                    <div class="globe-popup-location">${escapeHtml(props.location || 'Unknown')}</div>
+                    ${descriptionHtml}
+                    <div class="globe-popup-meta">
+                        <p><strong>Cluster:</strong> ${escapeHtml(props.mainCluster || 'Uncategorized')}</p>
+                        <p><strong>Country metric:</strong> ${metricDisplay} ${getMetricLabel()}</p>
+                    </div>
+                    ${moreInfoHtml}
                 </div>
             `)
             .addTo(globe);

--- a/data/artwork-data.json
+++ b/data/artwork-data.json
@@ -2157,7 +2157,7 @@
                 "artform": ["Painting"]
             },
 "url":"https://cambodianess.com/article/an-artist-raises-awareness-of-environment-and-wildlife-through-his-paintings", 
-            "thumbnail": ""
+            "thumbnail": "https://cambodianess.com/news/images/%E1%9E%82%E1%9E%93%E1%9F%92%E1%9E%9B%E1%9E%84%E1%9E%90%E1%9F%92%E1%9E%98%E1%9E%B8___New_Trajectory_CHHOEUN_Channy_1703319669.jpg"
         }
     },
     {
@@ -2548,7 +2548,7 @@
                     ]
                 },
                 "url": "https://www.art2030.org/projects/breathewithme",
-                "thumbnail": ""
+                "thumbnail": "https://images.ctfassets.net/j2t65vqbcf4l/1tTew1ERUtNaNueyZ42zI6/55dae8695057cde9a2c91eef6a023309/BL1A1860.jpg?fm=jpg&w=500&q=75"
             }
         },
         {
@@ -3229,7 +3229,8 @@
                         "Installation"
                     ]
                 },
-                "url": "https://www.alejandroduran.com/washed-up"
+                "url": "https://www.alejandroduran.com/washed-up",
+                "thumbnail": "https://images.squarespace-cdn.com/content/v1/5de0a7f224b1dd71d8856f9f/1596000342231-Y461N66MI9MHBFTI7IW7/Brotes.jpg?format=500w"
             }
         },
         
@@ -4177,7 +4178,7 @@
                     ]
                 },
                 "url": "https://www.plasticbottlevillage.com/",
-                "thumbnail": ""
+                "thumbnail": "https://images.squarespace-cdn.com/content/v1/57ee872dff7c5024e3000541/1550919974029-MTK6AKR5QBKCZZTCI4IT/PBV17.jpg?format=500w"
             }
         },
         {
@@ -4205,7 +4206,7 @@
                     ]
                 },
                 "url": "https://washedashore.org/",
-                "thumbnail": ""
+                "thumbnail": "https://ocean.si.edu/sites/default/files/styles/full_width_large/public/2023-11/plastic-jellyfish.jpg.webp?itok=xzIbM-ZP"
             }
         },
         {

--- a/style.css
+++ b/style.css
@@ -138,6 +138,10 @@
 
 .globe-popup {
   color: #111827;
+  display: grid;
+  gap: 0.45rem;
+  max-width: min(320px, calc(100vw - 3rem));
+  line-height: 1.35;
 }
 
 .globe-popup-thumbnail {
@@ -145,17 +149,54 @@
   width: 100%;
   max-height: 160px;
   object-fit: cover;
-  border-radius: 0.5rem;
-  margin: 0 0 0.75rem;
+  border-radius: 0.625rem;
+  margin: 0 0 0.25rem;
+  background: #e5e7eb;
 }
 
 .globe-popup h3 {
-  margin: 0 0 0.5rem;
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.25;
   font-weight: 700;
 }
 
 .globe-popup p {
-  margin: 0.25rem 0;
+  margin: 0.2rem 0;
+}
+
+.globe-popup-primary-meta,
+.globe-popup-location,
+.globe-popup-meta {
+  font-size: 0.82rem;
+}
+
+.globe-popup-primary-meta {
+  font-weight: 600;
+}
+
+.globe-popup-location,
+.globe-popup-description,
+.globe-popup-meta {
+  color: #4b5563;
+}
+
+.globe-popup-description {
+  font-size: 0.84rem;
+  border-top: 1px solid rgba(17, 24, 39, 0.08);
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+  padding: 0.5rem 0;
+}
+
+.globe-popup-link {
+  color: #0f766e;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.globe-popup-link:hover {
+  text-decoration: underline;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
### Motivation
- Reintroduce a short excerpt of `properties.description` in Explore popups so entries are more informative at a glance.  
- Improve thumbnail handling and loading (lightweight, async decoding, constrained sizing) to reduce popup layout jumps and bandwidth.  
- Keep popup content consistent between Globe View and Map View while preserving existing dataset fields and behavior.  

### Description
- Added helpers in `assets/js/globe.js`: `getDescriptionExcerpt(description, maxLength=180)` to normalize/collapse whitespace and truncate at word boundaries with an appended `…`, and `getValidUrl()` to validate external links; reused existing `escapeHtml()` for all inserted text.  
- Updated popup rendering in `assets/js/globe.js` to show thumbnail (if valid), title, compact `Artist, Year`, location, the description excerpt (below location and above cluster/metric), cluster/topics, country metric, and a bottom `More information` link when `properties.url` is a valid `http(s)` URL.  
- Improved thumbnail loading by preferring thumbnail URLs, adding `decoding="async"`, keeping `loading="lazy"`, and constraining images via CSS (width: 100%, `max-height: 160px`, `object-fit: cover`, rounded corners).  
- Updated popup styling in `style.css` to make `.globe-popup` a compact card with readable spacing, muted description text, compact metadata, subtle link styling, and mobile-friendly max width.  
- Added verified thumbnail URLs to `data/artwork-data.json` for these artworks: `New Trajectory`, `Breathe with Me`, `Museo de la Basura`, `Plastic Bottle Village`, and `Washed Ashore Project`.  
- Changed files: `assets/js/globe.js`, `style.css`, `data/artwork-data.json`.  
- Thumbnail source domains added: `cambodianess.com`, `images.ctfassets.net`, `images.squarespace-cdn.com`, and `ocean.si.edu`.

### Testing
- Ran `node --check assets/js/globe.js` and it succeeded.  
- Validated `data/artwork-data.json` with `node -e "JSON.parse(require('fs').readFileSync('data/artwork-data.json','utf8'))"` and it parsed successfully.  
- No automated test failures were produced by these checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bebca60588330a05308b0bda1fd0a)