### PR TITLE
Enhance globe popups: description excerpts, validated links, thumbnail handling, and styles

### DIFF
--- a/assets/js/globe.js
+++ b/assets/js/globe.js
@@ -40,7 +40,33 @@ function getThumbnailHtml(thumbnail) {
         return '';
     }
 
-    return `<img class="globe-popup-thumbnail" src="${escapeHtml(thumbnailUrl)}" alt="" loading="lazy">`;
+    return `<img class="globe-popup-thumbnail" src="${escapeHtml(thumbnailUrl)}" alt="" loading="lazy" decoding="async">`;
+}
+
+function getDescriptionExcerpt(description, maxLength = 180) {
+    const normalizedDescription = (description || '').toString().trim().replace(/\s+/g, ' ');
+
+    if (!normalizedDescription) {
+        return '';
+    }
+
+    if (normalizedDescription.length <= maxLength) {
+        return normalizedDescription;
+    }
+
+    const truncated = normalizedDescription.slice(0, maxLength).trimEnd();
+    const lastSpaceIndex = truncated.lastIndexOf(' ');
+    const excerpt = lastSpaceIndex > Math.floor(maxLength * 0.6)
+        ? truncated.slice(0, lastSpaceIndex).trimEnd()
+        : truncated;
+
+    return `${excerpt}…`;
+}
+
+function getValidUrl(value) {
+    const url = (value || '').toString().trim();
+
+    return /^https?:\/\/[^\s"'<>]+$/i.test(url) ? url : '';
 }
 
 function getCountryFromLocation(location) {
@@ -312,9 +338,16 @@ function addGlobeLayers() {
         const feature = event.features[0];
         const props = feature.properties || {};
         const coordinates = feature.geometry.coordinates.slice();
-        const metricValue = Number(props.countryMetric || 0);
-        const metricDisplay = getMetricMode() === 'perCapita' ? metricValue.toFixed(3) : metricValue.toFixed(0);
         const thumbnailHtml = getThumbnailHtml(props.thumbnail);
+        const descriptionExcerpt = getDescriptionExcerpt(props.description);
+        const descriptionHtml = descriptionExcerpt
+            ? `<p class="globe-popup-description">${escapeHtml(descriptionExcerpt)}</p>`
+            : '';
+        const artistText = props.year ? `${props.artist || 'Unknown'}, ${props.year}` : (props.artist || 'Unknown');
+        const moreInfoUrl = getValidUrl(props.url);
+        const moreInfoHtml = moreInfoUrl
+            ? `<a class="globe-popup-link" href="${escapeHtml(moreInfoUrl)}" target="_blank" rel="noopener noreferrer">More information</a>`
+            : '';
 
         new mapboxgl.Popup({ maxWidth: '320px' })
             .setLngLat(coordinates)
@@ -322,10 +355,13 @@ function addGlobeLayers() {
                 <div class="globe-popup">
                     ${thumbnailHtml}
                     <h3>${escapeHtml(props.title || 'Untitled')}</h3>
-                    <p><strong>Artist:</strong> ${escapeHtml(props.artist || 'Unknown')}</p>
-                    <p><strong>Location:</strong> ${escapeHtml(props.location || 'Unknown')}</p>
-                    <p><strong>Cluster:</strong> ${escapeHtml(props.mainCluster || 'Uncategorized')}</p>
-                    <p><strong>Country metric:</strong> ${metricDisplay} ${getMetricLabel()}</p>
+                    <div class="globe-popup-primary-meta">${escapeHtml(artistText)}</div>
+                    <div class="globe-popup-location">${escapeHtml(props.location || 'Unknown')}</div>
+                    ${descriptionHtml}
+                    <div class="globe-popup-meta">
+                        <p><strong>Cluster:</strong> ${escapeHtml(props.mainCluster || 'Uncategorized')}</p>
+                    </div>
+                    ${moreInfoHtml}
                 </div>
             `)
             .addTo(globe);

--- a/data/artwork-data.json
+++ b/data/artwork-data.json
@@ -2157,7 +2157,7 @@
                 "artform": ["Painting"]
             },
 "url":"https://cambodianess.com/article/an-artist-raises-awareness-of-environment-and-wildlife-through-his-paintings", 
-            "thumbnail": ""
+            "thumbnail": "https://cambodianess.com/news/images/%E1%9E%82%E1%9E%93%E1%9F%92%E1%9E%9B%E1%9E%84%E1%9E%90%E1%9F%92%E1%9E%98%E1%9E%B8___New_Trajectory_CHHOEUN_Channy_1703319669.jpg"
         }
     },
     {
@@ -2548,7 +2548,7 @@
                     ]
                 },
                 "url": "https://www.art2030.org/projects/breathewithme",
-                "thumbnail": ""
+                "thumbnail": "https://images.ctfassets.net/j2t65vqbcf4l/1tTew1ERUtNaNueyZ42zI6/55dae8695057cde9a2c91eef6a023309/BL1A1860.jpg?fm=jpg&w=500&q=75"
             }
         },
         {
@@ -3229,7 +3229,8 @@
                         "Installation"
                     ]
                 },
-                "url": "https://www.alejandroduran.com/washed-up"
+                "url": "https://www.alejandroduran.com/washed-up",
+                "thumbnail": "https://images.squarespace-cdn.com/content/v1/5de0a7f224b1dd71d8856f9f/1596000342231-Y461N66MI9MHBFTI7IW7/Brotes.jpg?format=500w"
             }
         },
         
@@ -4177,7 +4178,7 @@
                     ]
                 },
                 "url": "https://www.plasticbottlevillage.com/",
-                "thumbnail": ""
+                "thumbnail": "https://images.squarespace-cdn.com/content/v1/57ee872dff7c5024e3000541/1550919974029-MTK6AKR5QBKCZZTCI4IT/PBV17.jpg?format=500w"
             }
         },
         {
@@ -4205,7 +4206,7 @@
                     ]
                 },
                 "url": "https://washedashore.org/",
-                "thumbnail": ""
+                "thumbnail": "https://ocean.si.edu/sites/default/files/styles/full_width_large/public/2023-11/plastic-jellyfish.jpg.webp?itok=xzIbM-ZP"
             }
         },
         {

--- a/style.css
+++ b/style.css
@@ -138,6 +138,10 @@
 
 .globe-popup {
   color: #111827;
+  display: grid;
+  gap: 0.45rem;
+  max-width: min(320px, calc(100vw - 3rem));
+  line-height: 1.35;
 }
 
 .globe-popup-thumbnail {
@@ -145,17 +149,54 @@
   width: 100%;
   max-height: 160px;
   object-fit: cover;
-  border-radius: 0.5rem;
-  margin: 0 0 0.75rem;
+  border-radius: 0.625rem;
+  margin: 0 0 0.25rem;
+  background: #e5e7eb;
 }
 
 .globe-popup h3 {
-  margin: 0 0 0.5rem;
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.25;
   font-weight: 700;
 }
 
 .globe-popup p {
-  margin: 0.25rem 0;
+  margin: 0.2rem 0;
+}
+
+.globe-popup-primary-meta,
+.globe-popup-location,
+.globe-popup-meta {
+  font-size: 0.82rem;
+}
+
+.globe-popup-primary-meta {
+  font-weight: 600;
+}
+
+.globe-popup-location,
+.globe-popup-description,
+.globe-popup-meta {
+  color: #4b5563;
+}
+
+.globe-popup-description {
+  font-size: 0.84rem;
+  border-top: 1px solid rgba(17, 24, 39, 0.08);
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+  padding: 0.5rem 0;
+}
+
+.globe-popup-link {
+  color: #0f766e;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.globe-popup-link:hover {
+  text-decoration: underline;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
### Motivation
- Improve the globe feature popups to show a concise description excerpt, more useful primary metadata (artist/year), and a validated "More information" link for entries that provide a URL. 
- Improve thumbnail loading and decoding behaviors and ensure thumbnail URLs in the dataset are used where available. 
- Tidy popup layout and typography for better readability and consistent styling across viewports.

### Description
- Added `decoding="async"` to popup thumbnail images and created `getValidUrl()` to validate `http`/`https` links before rendering them. 
- Implemented `getDescriptionExcerpt()` to normalize, truncate, and produce a tidy description excerpt ending with an ellipsis when needed and integrated it into the popup HTML. 
- Reworked popup content to display a combined artist/year line, location, description excerpt, cluster meta, and an optional `More information` link, and removed the previous country metric display from the popup. 
- Updated CSS for `.globe-popup*` elements to use grid layout, spacing, thumbnail sizing/rounded corners, description separators, and link styles. 
- Populated several `thumbnail` fields and a small URL formatting fix in `data/artwork-data.json` so those popups show images and links when available.

### Testing
- No automated tests were modified or added for this change and no automated test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bebca60588330a05308b0bda1fd0a)