### PR TITLE
Remove country metric from artwork popup

### DIFF
--- a/assets/js/globe.js
+++ b/assets/js/globe.js
@@ -338,8 +338,6 @@ function addGlobeLayers() {
         const feature = event.features[0];
         const props = feature.properties || {};
         const coordinates = feature.geometry.coordinates.slice();
-        const metricValue = Number(props.countryMetric || 0);
-        const metricDisplay = getMetricMode() === 'perCapita' ? metricValue.toFixed(3) : metricValue.toFixed(0);
         const thumbnailHtml = getThumbnailHtml(props.thumbnail);
         const descriptionExcerpt = getDescriptionExcerpt(props.description);
         const descriptionHtml = descriptionExcerpt
@@ -362,7 +360,6 @@ function addGlobeLayers() {
                     ${descriptionHtml}
                     <div class="globe-popup-meta">
                         <p><strong>Cluster:</strong> ${escapeHtml(props.mainCluster || 'Uncategorized')}</p>
-                        <p><strong>Country metric:</strong> ${metricDisplay} ${getMetricLabel()}</p>
                     </div>
                     ${moreInfoHtml}
                 </div>


### PR DESCRIPTION
### Motivation
- Remove country-level metric values from the Explore/globe artwork popup so popups no longer display country totals or per-capita labels while leaving charts and rankings unchanged.

### Description
- Deleted the calculation and display of the country metric in the globe popup click handler by removing the `countryMetric`/metric display variables and the popup row that showed `Country metric` in `assets/js/globe.js`.

### Testing
- Ran `node --check assets/js/globe.js` and it completed successfully.
- Verified the popup strings were removed with `rg -n "getMetricLabel\(|countryMetric|globe-popup-meta" assets/js/globe.js` which returned expected results.
- Ran `git diff --check` which reported no whitespace or diff errors.
- Attempted `npx playwright --version` to generate a visual test but the install failed due to npm registry access (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bf0d1038c8330a5572f5fc0be2225)