### PR TITLE
Populate missing thumbnail URLs in artwork dataset

### DIFF
--- a/data/artwork-data.json
+++ b/data/artwork-data.json
@@ -966,7 +966,7 @@
         "artform": ["Photography"]
       },
       "url": "https://artsandculture.google.com/story/resilience-in-the-age-of-climate-change-art-works-for-change/xwVRB32tdJHdLg?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/01/M_Mattingly_DrySeason_web.jpg"
     }
   },
 
@@ -985,7 +985,7 @@
         "artform": ["Digital Art"]
       },
       "url": "https://artsandculture.google.com/story/art-with-an-ocean-view-art-works-for-change/iwVRP5j8b2P7KA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/01/C_Jordan_Whale.jpg"
     }
   },
   {
@@ -1003,7 +1003,7 @@
         "artform": ["Photography"]
       },
       "url": "https://artsandculture.google.com/story/art-with-an-ocean-view-art-works-for-change/iwVRP5j8b2P7KA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/01/C_Jordan_Midway.jpg"
     }
   },
   {
@@ -1021,7 +1021,7 @@
         "artform": ["Photography"]
       },
       "url": "https://artsandculture.google.com/story/art-with-an-ocean-view-art-works-for-change/iwVRP5j8b2P7KA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/01/D_Beltra_OilSpill12_web.jpg"
     }
   },
   {
@@ -1039,7 +1039,7 @@
         "artform": ["Photography"]
       },
       "url": "https://artsandculture.google.com/story/art-with-an-ocean-view-art-works-for-change/iwVRP5j8b2P7KA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/01/D_Beltra_OilSpill20_web.jpg"
     }
   },
   {
@@ -1093,7 +1093,7 @@
         "artform": ["Painting"]
       },
       "url": "https://artsandculture.google.com/story/art-with-an-ocean-view-art-works-for-change/iwVRP5j8b2P7KA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/02/W_Gladstone_WelcomeHomeIHTFP_web.jpg"
     }
   },
   {
@@ -1111,7 +1111,7 @@
         "artform": ["Painting"]
       },
       "url": "https://artsandculture.google.com/story/art-with-an-ocean-view-art-works-for-change/iwVRP5j8b2P7KA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2015/07/J_Yoshimoto_EvanescentEncounter.jpg"
     }
   },
   {
@@ -1129,7 +1129,7 @@
         "artform": ["Illustration"]
       },
       "url": "https://artsandculture.google.com/story/art-with-an-ocean-view-art-works-for-change/iwVRP5j8b2P7KA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/02/A_Grumet_FightingOverTheLastPieceOfSushi.jpg"
     }
   },
   {
@@ -1147,7 +1147,7 @@
         "artform": ["Photography"]
       },
       "url": "https://artsandculture.google.com/story/art-with-an-ocean-view-art-works-for-change/iwVRP5j8b2P7KA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/01/M_Mattingly_InflatableHome_web.jpg"
     }
   },
 
@@ -1166,7 +1166,7 @@
         "artform": ["Photography"]
       },
       "url": "https://artsandculture.google.com/story/beyond-the-waste-land-art-works-for-change/nQUB72ctwbOLJA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/01/C_Jordan_CellPhoneChargersAtlanta2004-1.jpg"
     }
   },
   {
@@ -1184,7 +1184,7 @@
         "artform": ["Photography"]
       },
       "url": "https://artsandculture.google.com/story/beyond-the-waste-land-art-works-for-change/nQUB72ctwbOLJA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/01/C_Jordan_RecyclingYard6Seattle-1.jpg"
     }
   },
   {
@@ -1202,7 +1202,7 @@
         "artform": ["Fashion", "Sculpture"]
       },
       "url": "https://artsandculture.google.com/story/beyond-the-waste-land-art-works-for-change/nQUB72ctwbOLJA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/03/N_Dextras_MapleFlapperJumper_web.jpg"
     }
   },
   {
@@ -1220,7 +1220,7 @@
         "artform": ["Sculpture", "Design"]
       },
       "url": "https://artsandculture.google.com/story/beyond-the-waste-land-art-works-for-change/nQUB72ctwbOLJA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/07/8-Phil-Ross-Mycotecture-IMG_1935.jpg"
     }
   },
   {
@@ -1238,7 +1238,7 @@
         "artform": ["Painting"]
       },
       "url": "https://artsandculture.google.com/story/beyond-the-waste-land-art-works-for-change/nQUB72ctwbOLJA?hl=en",
-      "thumbnail": ""
+      "thumbnail": "https://www.artworksforchange.org/wp-content/uploads/2016/02/S_Greene_StarsNTarnation.jpg"
     }
   },
   {


### PR DESCRIPTION
### Motivation
- Improve metadata completeness and visual rendering by populating missing `thumbnail` fields for artworks in the dataset.

### Description
- Updated `data/artwork-data.json` to replace empty `thumbnail` values with direct image URLs for numerous entries across the collection.
- Affected records include works such as "Dry Season", "Whale", "Oil Spill #12", "Oil Spill #20", "Welcome Home", "Evanescent Encounter", "Inflatable Home", and many others where `thumbnail` was previously an empty string.
- No changes were made to geometry, titles, descriptions, or other metadata fields beyond adding the thumbnail URLs.

### Testing
- No automated tests were run for this data-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cd9c14ab08330b1cec6f727518e62)