### PR TITLE
Improve artwork submission form

### DIFF
--- a/assets/js/submit-artwork.js
+++ b/assets/js/submit-artwork.js
@@ -30,14 +30,16 @@ function getCheckedValues(name) {
 function getFormData() {
     const longitude = document.getElementById('longitude').value;
     const latitude = document.getElementById('latitude').value;
+    const year = document.getElementById('year').value.trim();
 
     return {
         title: document.getElementById('title').value.trim(),
         artist: document.getElementById('artist').value.trim(),
         artform: getCheckedValues('artformOption'),
         proposedArtforms: splitList(document.getElementById('proposedArtforms').value),
-        year: parseInt(document.getElementById('year').value, 10),
+        year: year === '' ? '' : Number(year),
         location: document.getElementById('location').value.trim(),
+        country: document.getElementById('country').value.trim(),
         longitude: longitude === '' ? null : parseFloat(longitude),
         latitude: latitude === '' ? null : parseFloat(latitude),
         topics: getCheckedValues('topicOption'),
@@ -66,6 +68,7 @@ function buildArtworkFeature(data) {
             artist: data.artist,
             type: artforms[0] || '',
             location: data.location,
+            country: data.country,
             year: data.year || '',
             tags: {
                 topic: topics,
@@ -138,15 +141,30 @@ function updatePreview() {
     document.getElementById('jsonPreview').textContent = JSON.stringify(feature, null, 2);
 }
 
+function isHttpUrl(value) {
+    if (!value) return true;
+
+    try {
+        const url = new URL(value);
+        return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
 function validateSubmission(data) {
-    const required = ['title', 'artist', 'location', 'description', 'url'];
-    const missing = required.filter(field => !data[field]);
+    const messages = [];
 
-    if (!data.year) missing.push('year');
-    if (data.topics.length === 0 && data.proposedTopics.length === 0) missing.push('topics');
-    if (data.artform.length === 0 && data.proposedArtforms.length === 0) missing.push('artform');
+    if (!data.title) messages.push('title is required');
+    if (!data.artist) messages.push('artist is required');
+    if (!data.location) messages.push('location is required');
+    if (document.getElementById('year').value.trim() && !Number.isFinite(data.year)) {
+        messages.push('year should be numeric');
+    }
+    if (!isHttpUrl(data.url)) messages.push('source URL should start with http:// or https://');
+    if (!isHttpUrl(data.thumbnail)) messages.push('thumbnail URL should start with http:// or https://');
 
-    return missing;
+    return messages;
 }
 
 function buildIssueUrl(data, matches) {
@@ -173,6 +191,7 @@ function buildIssueUrl(data, matches) {
 **Artist:** ${data.artist}
 **Year:** ${data.year || 'Needs review'}
 **Location:** ${data.location}
+**Country:** ${data.country || 'Not provided'}
 **Submitter:** ${data.submitter || 'Not provided'}
 
 **Source URL:** ${data.url}
@@ -211,6 +230,20 @@ function handleDuplicateCheck() {
     setDuplicateStatus(matches);
 }
 
+async function handleCopyJson() {
+    const json = document.getElementById('jsonPreview').textContent;
+    const status = document.getElementById('duplicateStatus');
+
+    try {
+        await navigator.clipboard.writeText(json);
+        status.className = 'alert alert-success mb-5';
+        status.innerHTML = '<i class="ti ti-circle-check text-xl"></i><span>Generated JSON copied to clipboard.</span>';
+    } catch {
+        status.className = 'alert alert-warning mb-5';
+        status.innerHTML = '<i class="ti ti-alert-triangle text-xl"></i><span>Could not copy automatically. Select the generated JSON and copy it manually.</span>';
+    }
+}
+
 function handleCreateIssue() {
     const data = getFormData();
     const missing = validateSubmission(data);
@@ -218,7 +251,7 @@ function handleCreateIssue() {
     if (missing.length > 0) {
         const status = document.getElementById('duplicateStatus');
         status.className = 'alert alert-error mb-5';
-        status.innerHTML = `<i class="ti ti-alert-circle text-xl"></i><span>Missing required fields: ${missing.join(', ')}.</span>`;
+        status.innerHTML = `<i class="ti ti-alert-circle text-xl"></i><span>Please review: ${missing.join(', ')}.</span>`;
         return;
     }
 
@@ -301,6 +334,7 @@ document.getElementById('artworkSubmissionForm').addEventListener('reset', () =>
     }, 0);
 });
 document.getElementById('checkDuplicatesButton').addEventListener('click', handleDuplicateCheck);
+document.getElementById('copyJsonButton').addEventListener('click', handleCopyJson);
 document.getElementById('createIssueButton').addEventListener('click', handleCreateIssue);
 
 loadSubmissionData().catch(error => {

--- a/submit-artwork.html
+++ b/submit-artwork.html
@@ -42,20 +42,26 @@
                         <input id="artist" name="artist" type="text" class="input input-bordered" required>
                     </label>
                     <label class="form-control">
-                        <span class="label-text">Year *</span>
-                        <input id="year" name="year" type="number" class="input input-bordered" min="1800" max="2100" required>
+                        <span class="label-text">Year</span>
+                        <input id="year" name="year" type="text" inputmode="numeric" class="input input-bordered" placeholder="e.g. 2024">
+                        <span class="label-text-alt mt-1">Use a year if known; estimates can be noted in the description.</span>
                     </label>
                     <div class="form-control md:col-span-2">
-                        <span class="label-text">Existing art forms *</span>
+                        <span class="label-text">Art form / type</span>
                         <div id="artformOptions" class="submission-option-grid"></div>
                         <label class="form-control mt-3">
-                            <span class="label-text">Suggest new art form</span>
-                            <input id="proposedArtforms" name="proposedArtforms" type="text" class="input input-bordered" placeholder="Separate multiple suggestions with commas">
+                            <span class="label-text">Suggest new art form / type</span>
+                            <input id="proposedArtforms" name="proposedArtforms" type="text" class="input input-bordered" placeholder="Separate multiple suggestions with commas, e.g. mural, installation">
                         </label>
                     </div>
-                    <label class="form-control md:col-span-2">
+                    <label class="form-control">
                         <span class="label-text">Location *</span>
-                        <input id="location" name="location" type="text" class="input input-bordered" placeholder="City, Country" required>
+                        <input id="location" name="location" type="text" class="input input-bordered" placeholder="City, venue, or site" required>
+                        <span class="label-text-alt mt-1">Be as specific as possible, such as city, neighborhood, venue, or public site.</span>
+                    </label>
+                    <label class="form-control">
+                        <span class="label-text">Country</span>
+                        <input id="country" name="country" type="text" class="input input-bordered" placeholder="Country or region">
                     </label>
                     <label class="form-control">
                         <span class="label-text">Longitude</span>
@@ -66,25 +72,27 @@
                         <input id="latitude" name="latitude" type="number" class="input input-bordered" step="any" min="-90" max="90" placeholder="52.5200">
                     </label>
                     <div class="form-control md:col-span-2">
-                        <span class="label-text">Existing topics *</span>
+                        <span class="label-text">Topics</span>
                         <input id="topicSearch" type="search" class="input input-bordered mb-3" placeholder="Filter existing topics">
                         <div id="topicOptions" class="submission-option-grid submission-option-grid-tall"></div>
                         <label class="form-control mt-3">
                             <span class="label-text">Suggest new topics</span>
-                            <input id="proposedTopics" name="proposedTopics" type="text" class="input input-bordered" placeholder="Separate multiple suggestions with commas">
+                            <input id="proposedTopics" name="proposedTopics" type="text" class="input input-bordered" placeholder="Separate multiple suggestions with commas, e.g. climate justice, biodiversity">
                         </label>
                     </div>
                     <label class="form-control md:col-span-2">
-                        <span class="label-text">Description *</span>
-                        <textarea id="description" name="description" class="textarea textarea-bordered min-h-28" required></textarea>
+                        <span class="label-text">Short description</span>
+                        <textarea id="description" name="description" class="textarea textarea-bordered min-h-28" placeholder="Briefly describe the work, its environmental connection, and any review notes."></textarea>
                     </label>
                     <label class="form-control">
-                        <span class="label-text">Source URL *</span>
-                        <input id="url" name="url" type="url" class="input input-bordered" required>
+                        <span class="label-text">Artwork / source URL</span>
+                        <input id="url" name="url" type="url" class="input input-bordered" placeholder="https://example.org/artwork">
+                        <span class="label-text-alt mt-1">Please link to an official or reliable page about the artwork.</span>
                     </label>
                     <label class="form-control">
                         <span class="label-text">Thumbnail URL</span>
-                        <input id="thumbnail" name="thumbnail" type="url" class="input input-bordered">
+                        <input id="thumbnail" name="thumbnail" type="url" class="input input-bordered" placeholder="https://example.org/image.jpg">
+                        <span class="label-text-alt mt-1">Please use a stable image URL from Wikimedia Commons, an official artist/project page, museum, gallery, or another reliable source.</span>
                     </label>
                     <label class="form-control md:col-span-2">
                         <span class="label-text">Your name or contact</span>
@@ -112,7 +120,14 @@
                     <span>Fill in the form to check for similar existing artworks.</span>
                 </div>
 
-                <h3 class="text-xl font-semibold mb-2">Generated JSON</h3>
+                <div class="flex items-center justify-between gap-3 mb-2">
+                    <h3 class="text-xl font-semibold">Generated JSON</h3>
+                    <button id="copyJsonButton" type="button" class="btn btn-sm btn-outline">
+                        <i class="ti ti-copy text-lg"></i>
+                        Copy JSON
+                    </button>
+                </div>
+                <p class="text-sm opacity-80 mb-3">Review and copy this curator-ready data before opening an issue.</p>
                 <pre id="jsonPreview" class="submission-preview"></pre>
             </aside>
         </div>


### PR DESCRIPTION
### Motivation
- Reduce missing or low-quality submission data so community contributions are easier for curators to review. 
- Keep the form friendly and optional where appropriate while adding guidance and light client-side checks to catch common issues early.

### Description
- Updated `submit-artwork.html` to make `Year` a permissive numeric text field with helper copy, add a `Country` field, clarify the `Location` input, relabel `Art form / type` and `Topics`, add helpful placeholders and helper text for `Artwork / source URL` and `Thumbnail URL`, and add a `Copy JSON` button and short review hint next to the generated JSON preview.  
- Updated `assets/js/submit-artwork.js` to include `country` in `getFormData()` and the generated feature, parse `year` permissively, add `isHttpUrl()` URL checking, add client-side validation messages requiring `title`, `artist`, and `location`, validate that `year` is numeric if provided, validate that `url` and `thumbnail` (when provided) start with `http://` or `https://`, adjust the missing-field alert wording, include `country` in the issue body, and add a `handleCopyJson()` copy-to-clipboard handler wired to the new button.  
- Preserved existing artwork JSON files and did not alter Explore, Globe, Map, or Data Analysis behavior or server-side data formats; thumbnails remain optional to allow works without images.

### Testing
- Ran `git diff --check` to verify no whitespace or simple diff errors; it passed.  
- Ran `node --check assets/js/submit-artwork.js` to perform a syntax check on the updated JS file; it passed.  
- Attempted an automated page screenshot using Playwright but the run failed due to an environment `npm` registry access restriction (403), which is an infrastructure issue and not a code error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d1e10bf988330ad60f100a52aced0)