### PR TITLE
Polish virtual exhibition into museum gallery

### DIFF
--- a/assets/css/exhibition.css
+++ b/assets/css/exhibition.css
@@ -1,15 +1,18 @@
 .exhibition-shell {
   display: grid;
-  grid-template-rows: minmax(26rem, 60vh) auto;
+  grid-template-rows: minmax(28rem, 62vh) auto;
   flex: 1;
   min-height: 0;
+  background: #efe8dc;
 }
 
 .exhibition-stage {
   position: relative;
-  min-height: 26rem;
+  min-height: 28rem;
   overflow: hidden;
-  background: linear-gradient(180deg, #d9f3e6 0%, #7fa58e 58%, #364835 100%);
+  background:
+    radial-gradient(circle at 50% 10%, rgba(255, 250, 238, 0.94), rgba(236, 225, 209, 0.82) 44%, rgba(167, 148, 126, 0.75) 100%),
+    linear-gradient(180deg, #f7f2e8 0%, #ded0bd 100%);
 }
 
 .exhibition-canvas,
@@ -24,18 +27,30 @@
   left: 1rem;
   bottom: 1rem;
   max-width: calc(100% - 2rem);
-  padding: 0.6rem 0.8rem;
+  padding: 0.65rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
   border-radius: 999px;
-  color: #f8fafc;
-  background: rgba(15, 23, 42, 0.58);
+  color: #fbf7ef;
+  background: rgba(36, 32, 28, 0.66);
+  box-shadow: 0 18px 45px rgba(41, 32, 24, 0.24);
   font-size: 0.82rem;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
 }
 
 .exhibition-panel {
   padding: 1rem;
   overflow: auto;
   border-top: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+}
+
+.exhibition-tour {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.55rem;
+}
+
+.exhibition-tour .btn {
+  justify-content: center;
 }
 
 .exhibition-info {
@@ -61,6 +76,42 @@
 .exhibition-info a {
   color: hsl(var(--p));
   font-weight: 700;
+}
+
+.gallery-label {
+  position: absolute;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  max-width: 13rem;
+  white-space: normal;
+  text-align: center;
+  color: #32281f;
+  background: rgba(255, 253, 246, 0.92);
+  border: 1px solid rgba(60, 47, 36, 0.16);
+  border-radius: 0.25rem;
+  box-shadow: 0 0.45rem 1.5rem rgba(60, 47, 36, 0.12);
+  padding: 0.35rem 0.5rem;
+  font-size: 0.72rem;
+  line-height: 1.18;
+}
+
+.gallery-label--section {
+  max-width: 16rem;
+  padding: 0.45rem 0.8rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+@media (min-width: 520px) {
+  .exhibition-tour {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .exhibition-tour .btn:last-child {
+    grid-column: 1 / -1;
+  }
 }
 
 @media (min-width: 1024px) {

--- a/assets/js/exhibition.js
+++ b/assets/js/exhibition.js
@@ -3,18 +3,27 @@ import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/exampl
 
 const EcoData = window.EcoData;
 
-const MAX_ARTWORKS = 36;
-const MAX_PER_CONTINENT = 6;
+const MAX_ARTWORKS = 28;
+const MAX_PER_CONTINENT = 5;
 const THUMBNAIL_TIMEOUT_MS = 8000;
-const state = { artworks: [], topicClusters: {}, sceneObjects: [], labels: [], selected: null };
+const state = {
+  artworks: [],
+  topicClusters: {},
+  sceneObjects: [],
+  labels: [],
+  displayed: [],
+  selectedIndex: -1,
+  cameraGoal: null
+};
 
 const els = {
   mount: document.getElementById('exhibitionCanvas'),
   mode: document.getElementById('exhibitionMode'),
-  countryControl: document.getElementById('countryControl'),
-  country: document.getElementById('countrySelect'),
   topicControl: document.getElementById('topicControl'),
   topic: document.getElementById('topicSelect'),
+  previous: document.getElementById('previousArtwork'),
+  next: document.getElementById('nextArtwork'),
+  overview: document.getElementById('overviewGallery'),
   count: document.getElementById('exhibitionCount'),
   modeLabel: document.getElementById('exhibitionModeLabel'),
   info: document.getElementById('artworkInfo')
@@ -23,20 +32,25 @@ const els = {
 const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 renderer.shadowMap.enabled = true;
+renderer.outputColorSpace = THREE.SRGBColorSpace;
 els.mount.appendChild(renderer.domElement);
 
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(0xcfead8);
-scene.fog = new THREE.Fog(0xcfead8, 16, 55);
+scene.background = new THREE.Color(0xeee6da);
+scene.fog = new THREE.Fog(0xeee6da, 24, 58);
 
-const camera = new THREE.PerspectiveCamera(55, 1, 0.1, 120);
-camera.position.set(0, 8, 18);
+const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 120);
+camera.position.set(0, 4.2, 15.5);
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;
+controls.enablePan = false;
+controls.minPolarAngle = Math.PI * 0.28;
 controls.maxPolarAngle = Math.PI * 0.48;
-controls.minDistance = 7;
-controls.maxDistance = 34;
-controls.target.set(0, 2, 0);
+controls.minAzimuthAngle = -Math.PI * 0.45;
+controls.maxAzimuthAngle = Math.PI * 0.45;
+controls.minDistance = 6;
+controls.maxDistance = 19;
+controls.target.set(0, 1.8, -2.4);
 
 const raycaster = new THREE.Raycaster();
 const pointer = new THREE.Vector2();
@@ -56,26 +70,39 @@ function hasThumbnail(artwork) { return /^https?:\/\//i.test((artwork.properties
 function topicsFor(artwork) { return artwork.properties?.tags?.topic || []; }
 
 function initEnvironment() {
-  scene.add(new THREE.HemisphereLight(0xeafff3, 0x516345, 2.3));
-  const sun = new THREE.DirectionalLight(0xfff2c9, 2.2);
-  sun.position.set(-8, 14, 8);
-  sun.castShadow = true;
-  scene.add(sun);
+  scene.add(new THREE.HemisphereLight(0xfffbef, 0x97836b, 1.4));
+  addSpotLight(-6.5, 7.5, 2, -4, 1.7, -7);
+  addSpotLight(0, 7.8, 1.5, 0, 1.7, -8);
+  addSpotLight(6.5, 7.5, 2, 4, 1.7, -7);
 
-  const floor = new THREE.Mesh(new THREE.PlaneGeometry(70, 70), new THREE.MeshStandardMaterial({ color: 0x506b47, roughness: 0.92 }));
+  const wallMaterial = new THREE.MeshStandardMaterial({ color: 0xf4eee4, roughness: 0.86 });
+  const floorMaterial = new THREE.MeshStandardMaterial({ color: 0xb59a79, roughness: 0.78 });
+  const backWall = new THREE.Mesh(new THREE.BoxGeometry(36, 7.2, 0.28), wallMaterial);
+  backWall.position.set(0, 3.6, -10.5);
+  const leftWall = new THREE.Mesh(new THREE.BoxGeometry(0.28, 7.2, 24), wallMaterial);
+  leftWall.position.set(-18, 3.6, 1.2);
+  const rightWall = leftWall.clone();
+  rightWall.position.x = 18;
+  const floor = new THREE.Mesh(new THREE.PlaneGeometry(38, 28), floorMaterial);
   floor.rotation.x = -Math.PI / 2;
-  floor.receiveShadow = true;
-  scene.add(floor);
+  floor.position.z = 1.5;
+  [backWall, leftWall, rightWall, floor].forEach((object) => {
+    object.receiveShadow = true;
+    scene.add(object);
+  });
 
-  for (let i = 0; i < 18; i += 1) addPlant((Math.random() - 0.5) * 55, (Math.random() - 0.5) * 55);
+  const ceilingGlow = new THREE.Mesh(new THREE.PlaneGeometry(34, 9), new THREE.MeshBasicMaterial({ color: 0xfff5df, transparent: true, opacity: 0.14 }));
+  ceilingGlow.rotation.x = Math.PI / 2;
+  ceilingGlow.position.set(0, 7.18, -3);
+  scene.add(ceilingGlow);
 }
 
-function addPlant(x, z) {
-  const trunk = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.09, 0.9, 6), new THREE.MeshStandardMaterial({ color: 0x6b4f2a }));
-  trunk.position.set(x, 0.45, z);
-  const crown = new THREE.Mesh(new THREE.ConeGeometry(0.55, 1.5, 7), new THREE.MeshStandardMaterial({ color: 0x244d2c, roughness: 0.8 }));
-  crown.position.set(x, 1.45, z);
-  scene.add(trunk, crown);
+function addSpotLight(x, y, z, tx, ty, tz) {
+  const light = new THREE.SpotLight(0xffead0, 2.8, 26, Math.PI * 0.18, 0.6, 1.4);
+  light.position.set(x, y, z);
+  light.target.position.set(tx, ty, tz);
+  light.castShadow = true;
+  scene.add(light, light.target);
 }
 
 function clearExhibition() {
@@ -84,24 +111,24 @@ function clearExhibition() {
   state.labels.forEach((label) => label.remove());
   state.sceneObjects = [];
   state.labels = [];
+  state.displayed = [];
+  state.selectedIndex = -1;
 }
 
 function addTracked(object) { state.sceneObjects.push(object); scene.add(object); return object; }
 
-function createPanel(x, z, rotationY, width = 5.4, label = '') {
-  const panel = addTracked(new THREE.Mesh(new THREE.BoxGeometry(width, 3.4, 0.18), new THREE.MeshStandardMaterial({ color: 0xd7c9a3, roughness: 0.85 })));
-  panel.position.set(x, 1.7, z);
+function createWallSection(x, z, rotationY, width = 5.6, label = '') {
+  const panel = addTracked(new THREE.Mesh(new THREE.BoxGeometry(width, 3.75, 0.2), new THREE.MeshStandardMaterial({ color: 0xf8f4ec, roughness: 0.82 })));
+  panel.position.set(x, 2.28, z);
   panel.rotation.y = rotationY;
-  panel.castShadow = true;
   panel.receiveShadow = true;
-  if (label) createHtmlLabel(label, x, 3.85, z, 'font-weight:700;font-size:1rem;');
+  if (label) createHtmlLabel(label, x, 4.45, z, 'gallery-label--section');
   return panel;
 }
 
-function createHtmlLabel(text, x, y, z, extraStyle = '') {
+function createHtmlLabel(text, x, y, z, className = '') {
   const label = document.createElement('div');
-  label.className = 'badge badge-primary shadow';
-  label.style.cssText = `position:absolute;pointer-events:none;transform:translate(-50%,-50%);max-width:180px;text-align:center;white-space:normal;${extraStyle}`;
+  label.className = `gallery-label ${className}`.trim();
   label.textContent = text;
   els.mount.appendChild(label);
   state.labels.push(label);
@@ -118,27 +145,49 @@ function textureFor(url) {
   });
 }
 
-async function addArtwork(artwork, x, z, rotationY) {
-  const panel = createPanel(x, z, rotationY);
+async function addArtwork(artwork, x, z, rotationY, sectionLabel = '') {
+  createWallSection(x, z, rotationY, 4.6, sectionLabel);
   const normal = new THREE.Vector3(0, 0, 1).applyAxisAngle(new THREE.Vector3(0, 1, 0), rotationY);
-  const artPos = new THREE.Vector3(x, 1.95, z).addScaledVector(normal, 0.12);
+  const artPos = new THREE.Vector3(x, 2.35, z).addScaledVector(normal, 0.14);
   const texture = await textureFor(artwork.properties.thumbnail.trim());
   if (!texture) return;
-  const frame = addTracked(new THREE.Mesh(new THREE.BoxGeometry(2.35, 1.75, 0.12), new THREE.MeshStandardMaterial({ color: 0x3c2b18, roughness: 0.7 })));
+
+  const frame = addTracked(new THREE.Mesh(new THREE.BoxGeometry(2.28, 1.76, 0.16), new THREE.MeshStandardMaterial({ color: 0x2e2822, metalness: 0.08, roughness: 0.48 })));
   frame.position.copy(artPos);
   frame.rotation.y = rotationY;
-  const image = addTracked(new THREE.Mesh(new THREE.PlaneGeometry(2.05, 1.45), new THREE.MeshBasicMaterial({ map: texture })));
-  image.position.copy(artPos).addScaledVector(normal, 0.08);
+  frame.castShadow = true;
+  const mat = addTracked(new THREE.Mesh(new THREE.BoxGeometry(2.06, 1.54, 0.06), new THREE.MeshStandardMaterial({ color: 0xf7f2e9, roughness: 0.9 })));
+  mat.position.copy(artPos).addScaledVector(normal, 0.06);
+  mat.rotation.y = rotationY;
+  const image = addTracked(new THREE.Mesh(new THREE.PlaneGeometry(1.82, 1.3), new THREE.MeshBasicMaterial({ map: texture })));
+  image.position.copy(artPos).addScaledVector(normal, 0.105);
   image.rotation.y = rotationY;
   image.userData.artwork = artwork;
+  image.userData.focus = artPos.clone().addScaledVector(normal, 4.6).setY(2.35);
+  image.userData.target = artPos.clone();
   clickable.push(image);
+  state.displayed.push({ artwork, object: image });
+
   const p = artwork.properties;
-  createHtmlLabel(`${p.title || 'Untitled'}\n${p.artist || 'Unknown'}${p.year ? `, ${p.year}` : ''}`, artPos.x, 0.55, artPos.z, 'font-size:.72rem;line-height:1.15;');
+  createHtmlLabel(`${p.title || 'Untitled'}\n${p.artist || 'Unknown'}${p.year ? `, ${p.year}` : ''}`, artPos.x, 0.82, artPos.z);
+}
+
+function galleryPositions(count) {
+  const positions = [];
+  const perRow = Math.min(7, Math.max(3, Math.ceil(Math.sqrt(count))));
+  for (let index = 0; index < count; index += 1) {
+    const row = Math.floor(index / perRow);
+    const col = index % perRow;
+    positions.push({ x: (col - (perRow - 1) / 2) * 4.8, z: -10.2 + row * 4.7, rotationY: 0 });
+  }
+  return positions;
 }
 
 function layoutLine(artworks, heading) {
-  createHtmlLabel(heading, 0, 4.4, -7.5, 'font-size:1.05rem;font-weight:700;');
-  artworks.slice(0, MAX_ARTWORKS).forEach((artwork, index) => addArtwork(artwork, (index % 6 - 2.5) * 5.8, -8 + Math.floor(index / 6) * 5.2, 0));
+  createHtmlLabel(heading, 0, 5.0, -10.2, 'gallery-label--section');
+  const selected = artworks.slice(0, MAX_ARTWORKS);
+  galleryPositions(selected.length).forEach((pos, index) => addArtwork(selected[index], pos.x, pos.z, pos.rotationY));
+  els.count.textContent = selected.length;
 }
 
 function layoutContinents() {
@@ -149,44 +198,40 @@ function layoutContinents() {
     return acc;
   }, new Map());
   const continents = [...groups.keys()].sort();
-  continents.forEach((continent, zoneIndex) => {
-    const angle = (zoneIndex / Math.max(continents.length, 1)) * Math.PI * 2;
-    const radius = 11;
-    const cx = Math.cos(angle) * radius;
-    const cz = Math.sin(angle) * radius;
-    createHtmlLabel(continent, cx, 4.2, cz, 'font-size:1.05rem;font-weight:700;');
-    groups.get(continent).sort(byYearAscending).slice(0, MAX_PER_CONTINENT).forEach((artwork, i) => {
-      addArtwork(artwork, cx + (i - 2.5) * 2.8 * Math.cos(angle + Math.PI / 2), cz + (i - 2.5) * 2.8 * Math.sin(angle + Math.PI / 2), -angle + Math.PI / 2);
+  const positions = galleryPositions(continents.length * MAX_PER_CONTINENT);
+  let used = 0;
+  continents.forEach((continent) => {
+    groups.get(continent).sort(byYearAscending).slice(0, MAX_PER_CONTINENT).forEach((artwork, index) => {
+      const pos = positions[used];
+      addArtwork(artwork, pos.x, pos.z, pos.rotationY, index === 0 ? continent : '');
+      used += 1;
     });
   });
-  els.count.textContent = Math.min(state.artworks.length, continents.length * MAX_PER_CONTINENT);
+  els.count.textContent = used;
 }
 
 function currentSelection() {
-  const mode = els.mode.value;
-  if (mode === 'continent') return null;
-  if (mode === 'country') return state.artworks.filter((a) => a.properties.country === els.country.value).sort(byYearAscending);
-  if (mode === 'topic') return state.artworks.filter((a) => a.properties.clusters.includes(els.topic.value) || topicsFor(a).includes(els.topic.value)).sort(byYearAscending);
+  if (els.mode.value === 'continent') return null;
+  if (els.mode.value === 'topic') return state.artworks.filter((a) => a.properties.clusters.includes(els.topic.value) || topicsFor(a).includes(els.topic.value)).sort(byYearAscending);
   return [...state.artworks].sort(byYearAscending);
 }
 
 function renderMode() {
   clearExhibition();
-  els.countryControl.classList.toggle('hidden', els.mode.value !== 'country');
   els.topicControl.classList.toggle('hidden', els.mode.value !== 'topic');
   els.modeLabel.textContent = els.mode.selectedOptions[0].textContent;
-  if (els.mode.value === 'continent') return layoutContinents();
-  const selected = currentSelection();
-  els.count.textContent = Math.min(selected.length, MAX_ARTWORKS);
-  layoutLine(selected, els.mode.value === 'timeline' ? 'Chronological path' : (els.country.value || els.topic.value));
+  if (els.mode.value === 'continent') layoutContinents();
+  else {
+    const selected = currentSelection();
+    layoutLine(selected, els.mode.value === 'timeline' ? 'Chronological gallery path' : els.topic.value);
+  }
+  focusOverview();
 }
 
 function populateControls() {
-  const countries = [...new Set(state.artworks.map((a) => a.properties.country).filter(Boolean))].sort();
-  els.country.innerHTML = countries.map((country) => `<option>${country}</option>`).join('');
   const topics = new Set(Object.keys(state.topicClusters));
   state.artworks.forEach((a) => topicsFor(a).forEach((topic) => topics.add(topic)));
-  els.topic.innerHTML = [...topics].sort().map((topic) => `<option>${topic}</option>`).join('');
+  els.topic.innerHTML = [...topics].sort().map((topic) => `<option>${escapeHtml(topic)}</option>`).join('');
 }
 
 function showInfo(artwork) {
@@ -194,7 +239,7 @@ function showInfo(artwork) {
   els.info.innerHTML = `<h2 class="text-xl font-semibold">${escapeHtml(p.title || 'Untitled')}</h2><dl>
     <div><dt>Artist</dt><dd>${escapeHtml(p.artist || 'Unknown')}</dd></div>
     <div><dt>Year</dt><dd>${escapeHtml(p.year || 'Unknown')}</dd></div>
-    <div><dt>Continent / Country</dt><dd>${escapeHtml(p.continent || 'Other')} / ${escapeHtml(p.country || 'Other')}</dd></div>
+    <div><dt>Continent</dt><dd>${escapeHtml(p.continent || 'Other')}</dd></div>
     <div><dt>Location</dt><dd>${escapeHtml(p.location || 'Unknown')}</dd></div>
     <div><dt>Topics</dt><dd>${escapeHtml(topicsFor(artwork).join(', ') || 'Uncategorized')}</dd></div>
     <div><dt>Description</dt><dd>${escapeHtml((p.description || 'No description available.').slice(0, 240))}${p.description?.length > 240 ? '…' : ''}</dd></div>
@@ -206,13 +251,34 @@ function escapeHtml(value) {
   return String(value).replace(/[&<>'"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[char]));
 }
 
+function focusArtwork(index) {
+  if (!state.displayed.length) return;
+  state.selectedIndex = (index + state.displayed.length) % state.displayed.length;
+  const item = state.displayed[state.selectedIndex];
+  showInfo(item.artwork);
+  state.cameraGoal = {
+    position: item.object.userData.focus,
+    target: item.object.userData.target
+  };
+}
+
+function focusOverview() {
+  state.cameraGoal = {
+    position: new THREE.Vector3(0, 4.2, 15.5),
+    target: new THREE.Vector3(0, 1.85, -3.2)
+  };
+}
+
 function onPointerDown(event) {
   const rect = renderer.domElement.getBoundingClientRect();
   pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
   pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
   raycaster.setFromCamera(pointer, camera);
   const hit = raycaster.intersectObjects(clickable)[0];
-  if (hit?.object.userData.artwork) showInfo(hit.object.userData.artwork);
+  if (hit?.object.userData.artwork) {
+    const index = state.displayed.findIndex((item) => item.object === hit.object);
+    focusArtwork(index);
+  }
 }
 
 function resize() {
@@ -235,6 +301,11 @@ function updateLabels() {
 
 function animate() {
   requestAnimationFrame(animate);
+  if (state.cameraGoal) {
+    camera.position.lerp(state.cameraGoal.position, 0.075);
+    controls.target.lerp(state.cameraGoal.target, 0.075);
+    if (camera.position.distanceTo(state.cameraGoal.position) < 0.04 && controls.target.distanceTo(state.cameraGoal.target) < 0.04) state.cameraGoal = null;
+  }
   controls.update();
   updateLabels();
   renderer.render(scene, camera);
@@ -254,8 +325,10 @@ async function init() {
 }
 
 els.mode.addEventListener('change', renderMode);
-els.country.addEventListener('change', renderMode);
 els.topic.addEventListener('change', renderMode);
+els.previous.addEventListener('click', () => focusArtwork(state.selectedIndex - 1));
+els.next.addEventListener('click', () => focusArtwork(state.selectedIndex + 1));
+els.overview.addEventListener('click', focusOverview);
 renderer.domElement.addEventListener('pointerdown', onPointerDown);
 window.addEventListener('resize', resize);
 

--- a/exhibition.html
+++ b/exhibition.html
@@ -38,27 +38,21 @@
 
     <main class="exhibition-shell">
         <section class="exhibition-stage">
-            <div id="exhibitionCanvas" class="exhibition-canvas" aria-label="3D virtual exhibition"></div>
-            <div class="exhibition-help">Drag to look around • Scroll/pinch to zoom • Click a framed artwork for details</div>
+            <div id="exhibitionCanvas" class="exhibition-canvas" aria-label="3D museum-style virtual exhibition"></div>
+            <div class="exhibition-help">Use Previous / Next for a guided tour • Reset returns to the full gallery • Drag gently to adjust the view • Click framed artworks for details</div>
         </section>
 
         <aside class="exhibition-panel bg-base-200">
-            <h1 class="text-2xl font-bold">Virtual Exhibition Pavilion</h1>
-            <p class="mt-3 text-sm opacity-80">An experimental first exhibition space for eco:nection: framed artworks are arranged in an open-air environmental pavilion using archive thumbnails and lightweight 3D geometry.</p>
+            <h1 class="text-2xl font-bold">Virtual Museum Gallery</h1>
+            <p class="mt-3 text-sm opacity-80">A calm, curated room of framed eco:nection artworks with wall labels, gallery lighting, and simple guided navigation.</p>
 
             <label class="form-control mt-5">
                 <span class="label-text">Curatorial mode</span>
                 <select id="exhibitionMode" class="select select-bordered">
                     <option value="continent" selected>Continent</option>
-                    <option value="country">Country</option>
                     <option value="topic">Topic</option>
                     <option value="timeline">Timeline</option>
                 </select>
-            </label>
-
-            <label id="countryControl" class="form-control mt-4 hidden">
-                <span class="label-text">Country</span>
-                <select id="countrySelect" class="select select-bordered"></select>
             </label>
 
             <label id="topicControl" class="form-control mt-4 hidden">
@@ -66,14 +60,21 @@
                 <select id="topicSelect" class="select select-bordered"></select>
             </label>
 
+            <div class="exhibition-tour mt-5" aria-label="Guided artwork navigation">
+                <button id="previousArtwork" class="btn btn-outline btn-sm"><i class="ti ti-chevron-left"></i>Previous artwork</button>
+                <button id="nextArtwork" class="btn btn-primary btn-sm">Next artwork<i class="ti ti-chevron-right"></i></button>
+                <button id="overviewGallery" class="btn btn-ghost btn-sm"><i class="ti ti-home"></i>Reset / Overview</button>
+            </div>
+            <p class="mt-3 text-xs opacity-70">Tip: the guided buttons move between works in the current curatorial sequence. Orbit controls are available only for small adjustments.</p>
+
             <div class="stats stats-vertical shadow w-full mt-5">
                 <div class="stat"><div class="stat-title">Displayed artworks</div><div id="exhibitionCount" class="stat-value text-primary">0</div></div>
                 <div class="stat"><div class="stat-title">Mode</div><div id="exhibitionModeLabel" class="stat-value text-secondary text-lg">Continent</div></div>
             </div>
 
             <section id="artworkInfo" class="exhibition-info mt-5 rounded-box border border-base-300 bg-base-100 p-4">
-                <h2 class="text-xl font-semibold">Select an artwork</h2>
-                <p class="mt-2 text-sm opacity-75">Artwork details will appear here.</p>
+                <h2 class="text-xl font-semibold">Begin the guided tour</h2>
+                <p class="mt-2 text-sm opacity-75">Select Next artwork or click a framed work to view artwork details here.</p>
             </section>
         </aside>
     </main>


### PR DESCRIPTION
### Motivation
- Replace the rudimentary outdoor pavilion and playful forest aesthetic with a calm, curated museum/gallery experience that feels like a real exhibition room. 
- Simplify the curatorial UX by removing Country mode and focusing on Continent, Topic, and Timeline modes for a clearer, lighter MVP. 
- Improve navigation and accessibility by adding simple guided controls (Previous / Next / Reset) and camera focus behavior while keeping lightweight orbit controls as a secondary option. 

### Description
- Updated `exhibition.html` to retitle the page, remove the country dropdown and Country option, add guided navigation buttons (`previousArtwork`, `nextArtwork`, `overviewGallery`), helper copy, and keep Topic/Continent/Timeline selectors. 
- Rewrote `assets/js/exhibition.js` to remove Country mode logic, add a museum interior environment (walls, warm floor, ceiling glow, spotlights), create framed + matted artworks with wall sections and HTML wall labels, constrain `OrbitControls`, add guided camera focus (`state.cameraGoal`, `focusArtwork`, `focusOverview`) with smooth lerp transitions, track displayed artworks for guided navigation, cap artwork counts, and continue skipping missing thumbnails. 
- Restyled `assets/css/exhibition.css` with a neutral/warm gallery background, refined helper pill, gallery label styles, responsive tour button layout, and panel spacing to support the museum look. 
- Preserved existing thumbnail-based textures, avoided large 3D models, and kept performance-friendly limits suitable for GitHub Pages. 

### Testing
- Ran `node --check assets/js/exhibition.js` which completed successfully. 
- Served the site with `python3 -m http.server 4173` and verified `exhibition.html`, `index.html`, and `data-analysis.html` returned successfully via `curl`. 
- Verified Country mode and country dropdown references were removed by searching files (no matches found). 
- Verified Continent, Topic, and Timeline UI options and the guided controls (`previousArtwork`, `nextArtwork`, `overviewGallery`, `topicControl`) are present and wired in the JS by static inspection. 
- Confirmed via static review that artworks are displayed as framed/matted pieces on interior wall sections with wall labels, that clicking an artwork focuses it and opens the info panel, and that guided Previous/Next/Overview focus behavior is implemented. 
- Attempted to run a browser automation snapshot, but `npx playwright` could not install in this environment due to an external npm registry `403 Forbidden`, so no automated browser screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d387471d08330ab4e6ff66667d691)