### PR TITLE
Exhibition overhaul: architectural rooms, gallery modes, async rendering and monthly rotation

### DIFF
--- a/assets/css/exhibition.css
+++ b/assets/css/exhibition.css
@@ -1,18 +1,16 @@
 .exhibition-shell {
   display: grid;
-  grid-template-rows: minmax(30rem, 64vh) auto;
+  grid-template-rows: minmax(28rem, 62vh) auto;
   flex: 1;
   min-height: 0;
-  background: #e7ded2;
+  background: #e9dfd1;
 }
 
 .exhibition-stage {
   position: relative;
-  min-height: 30rem;
+  min-height: 28rem;
   overflow: hidden;
-  background:
-    radial-gradient(circle at 50% 5%, rgba(255, 248, 231, 0.55), transparent 42%),
-    linear-gradient(180deg, #171512 0%, #6b5d4e 48%, #d7c8b7 100%);
+  background: linear-gradient(180deg, #efe7dc 0%, #d3bfaa 100%);
 }
 
 .exhibition-canvas,
@@ -29,14 +27,14 @@
   bottom: 1rem;
   max-width: calc(100% - 2rem);
   z-index: 2;
-  padding: 0.7rem 0.95rem;
-  border: 1px solid rgba(255, 245, 221, 0.36);
+  padding: 0.65rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
   border-radius: 999px;
-  color: #fff7ea;
-  background: rgba(22, 20, 18, 0.74);
-  box-shadow: 0 18px 45px rgba(25, 20, 16, 0.28);
+  color: #fbf7ef;
+  background: rgba(36, 32, 28, 0.72);
+  box-shadow: 0 18px 45px rgba(41, 32, 24, 0.24);
   font-size: 0.82rem;
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(8px);
   pointer-events: none;
 }
 
@@ -48,22 +46,6 @@
   border-top: 1px solid color-mix(in srgb, currentColor 12%, transparent);
 }
 
-.exhibition-rotation-note {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.45rem 0.65rem;
-  border: 1px solid color-mix(in srgb, hsl(var(--p)) 28%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, hsl(var(--p)) 9%, transparent);
-  color: color-mix(in srgb, hsl(var(--p)) 78%, currentColor);
-  font-weight: 700;
-}
-
-.exhibition-rotation-note::before {
-  content: "✦";
-}
-
 .exhibition-tour {
   display: grid;
   grid-template-columns: 1fr;
@@ -72,8 +54,7 @@
 
 .exhibition-tour .btn {
   justify-content: center;
-  min-height: 2.7rem;
-  white-space: normal;
+  min-height: 2.65rem;
 }
 
 .exhibition-info {
@@ -87,19 +68,9 @@
   font-size: 0.9rem;
 }
 
-.exhibition-info dt {
-  font-weight: 700;
-}
-
-.exhibition-info dd {
-  margin: 0;
-  opacity: 0.82;
-}
-
-.exhibition-info a {
-  color: hsl(var(--p));
-  font-weight: 700;
-}
+.exhibition-info dt { font-weight: 700; }
+.exhibition-info dd { margin: 0; opacity: 0.82; }
+.exhibition-info a { color: hsl(var(--p)); font-weight: 700; }
 
 .gallery-label {
   position: absolute;
@@ -109,44 +80,36 @@
   max-width: 11rem;
   white-space: pre-line;
   text-align: center;
-  color: #302820;
-  background: rgba(255, 253, 246, 0.94);
-  border: 1px solid rgba(71, 56, 42, 0.18);
+  color: #332b22;
+  background: rgba(255, 253, 247, 0.94);
+  border: 1px solid rgba(60, 47, 36, 0.18);
   border-radius: 0.18rem;
-  box-shadow: 0 0.35rem 1rem rgba(45, 35, 27, 0.12);
-  padding: 0.3rem 0.45rem;
-  font-size: 0.64rem;
-  line-height: 1.14;
+  box-shadow: 0 0.35rem 1rem rgba(60, 47, 36, 0.1);
+  padding: 0.28rem 0.42rem;
+  font-size: 0.62rem;
+  line-height: 1.15;
 }
 
-.gallery-label--room {
-  max-width: 15rem;
-  padding: 0.4rem 0.72rem;
-  border-color: rgba(211, 164, 76, 0.32);
-  background: rgba(255, 249, 235, 0.96);
-  font-size: 0.84rem;
+.gallery-label--section {
+  max-width: 14rem;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.85rem;
   font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 @media (min-width: 520px) {
-  .exhibition-tour {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  .exhibition-tour { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (min-width: 1024px) {
   .exhibition-shell {
-    grid-template-columns: minmax(0, 1fr) 25.5rem;
+    grid-template-columns: minmax(0, 1fr) 25rem;
     grid-template-rows: minmax(0, 1fr);
     height: calc(100vh - 4rem);
   }
-
-  .exhibition-stage {
-    min-height: 0;
-  }
-
+  .exhibition-stage { min-height: 0; }
   .exhibition-panel {
     height: 100%;
     border-top: 0;

--- a/assets/css/exhibition.css
+++ b/assets/css/exhibition.css
@@ -1,18 +1,18 @@
 .exhibition-shell {
   display: grid;
-  grid-template-rows: minmax(28rem, 62vh) auto;
+  grid-template-rows: minmax(30rem, 64vh) auto;
   flex: 1;
   min-height: 0;
-  background: #efe8dc;
+  background: #e7ded2;
 }
 
 .exhibition-stage {
   position: relative;
-  min-height: 28rem;
+  min-height: 30rem;
   overflow: hidden;
   background:
-    radial-gradient(circle at 50% 10%, rgba(255, 250, 238, 0.94), rgba(236, 225, 209, 0.82) 44%, rgba(167, 148, 126, 0.75) 100%),
-    linear-gradient(180deg, #f7f2e8 0%, #ded0bd 100%);
+    radial-gradient(circle at 50% 5%, rgba(255, 248, 231, 0.55), transparent 42%),
+    linear-gradient(180deg, #171512 0%, #6b5d4e 48%, #d7c8b7 100%);
 }
 
 .exhibition-canvas,
@@ -20,6 +20,7 @@
   display: block;
   width: 100%;
   height: 100%;
+  touch-action: none;
 }
 
 .exhibition-help {
@@ -27,20 +28,40 @@
   left: 1rem;
   bottom: 1rem;
   max-width: calc(100% - 2rem);
-  padding: 0.65rem 0.9rem;
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  z-index: 2;
+  padding: 0.7rem 0.95rem;
+  border: 1px solid rgba(255, 245, 221, 0.36);
   border-radius: 999px;
-  color: #fbf7ef;
-  background: rgba(36, 32, 28, 0.66);
-  box-shadow: 0 18px 45px rgba(41, 32, 24, 0.24);
+  color: #fff7ea;
+  background: rgba(22, 20, 18, 0.74);
+  box-shadow: 0 18px 45px rgba(25, 20, 16, 0.28);
   font-size: 0.82rem;
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(10px);
+  pointer-events: none;
 }
 
 .exhibition-panel {
+  position: relative;
+  z-index: 3;
   padding: 1rem;
   overflow: auto;
   border-top: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+}
+
+.exhibition-rotation-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid color-mix(in srgb, hsl(var(--p)) 28%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, hsl(var(--p)) 9%, transparent);
+  color: color-mix(in srgb, hsl(var(--p)) 78%, currentColor);
+  font-weight: 700;
+}
+
+.exhibition-rotation-note::before {
+  content: "✦";
 }
 
 .exhibition-tour {
@@ -51,6 +72,8 @@
 
 .exhibition-tour .btn {
   justify-content: center;
+  min-height: 2.7rem;
+  white-space: normal;
 }
 
 .exhibition-info {
@@ -80,27 +103,30 @@
 
 .gallery-label {
   position: absolute;
+  z-index: 1;
   pointer-events: none;
   transform: translate(-50%, -50%);
-  max-width: 13rem;
-  white-space: normal;
+  max-width: 11rem;
+  white-space: pre-line;
   text-align: center;
-  color: #32281f;
-  background: rgba(255, 253, 246, 0.92);
-  border: 1px solid rgba(60, 47, 36, 0.16);
-  border-radius: 0.25rem;
-  box-shadow: 0 0.45rem 1.5rem rgba(60, 47, 36, 0.12);
-  padding: 0.35rem 0.5rem;
-  font-size: 0.72rem;
-  line-height: 1.18;
+  color: #302820;
+  background: rgba(255, 253, 246, 0.94);
+  border: 1px solid rgba(71, 56, 42, 0.18);
+  border-radius: 0.18rem;
+  box-shadow: 0 0.35rem 1rem rgba(45, 35, 27, 0.12);
+  padding: 0.3rem 0.45rem;
+  font-size: 0.64rem;
+  line-height: 1.14;
 }
 
-.gallery-label--section {
-  max-width: 16rem;
-  padding: 0.45rem 0.8rem;
-  font-size: 0.95rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+.gallery-label--room {
+  max-width: 15rem;
+  padding: 0.4rem 0.72rem;
+  border-color: rgba(211, 164, 76, 0.32);
+  background: rgba(255, 249, 235, 0.96);
+  font-size: 0.84rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -108,15 +134,11 @@
   .exhibition-tour {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-
-  .exhibition-tour .btn:last-child {
-    grid-column: 1 / -1;
-  }
 }
 
 @media (min-width: 1024px) {
   .exhibition-shell {
-    grid-template-columns: minmax(0, 1fr) 25rem;
+    grid-template-columns: minmax(0, 1fr) 25.5rem;
     grid-template-rows: minmax(0, 1fr);
     height: calc(100vh - 4rem);
   }

--- a/assets/js/exhibition.js
+++ b/assets/js/exhibition.js
@@ -2,527 +2,105 @@ import * as THREE from 'three';
 import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/controls/OrbitControls.js';
 
 const EcoData = window.EcoData;
-
-const MAX_TOTAL_ARTWORKS = 56;
-const MAX_PER_CONTINENT = 8;
-const MAX_TOPIC_ARTWORKS = 18;
+const MAX_ARTWORKS = 30;
+const MAX_PER_CONTINENT = 3;
+const MAX_ROOM_ARTWORKS = 10;
 const THUMBNAIL_TIMEOUT_MS = 6500;
-const MONTH_SEED = new Date().toISOString().slice(0, 7);
 
-const GALLERIES = {
-  continent: {
-    name: 'Continent Gallery',
-    shortName: 'Continent',
-    center: new THREE.Vector3(-13.5, 0, -6.6),
-    overview: new THREE.Vector3(-13.5, 3.45, 2.1),
-    target: new THREE.Vector3(-13.5, 2.0, -8.8)
-  },
-  topic: {
-    name: 'Topic Gallery',
-    shortName: 'Topic',
-    center: new THREE.Vector3(0, 0, -7.2),
-    overview: new THREE.Vector3(0, 3.55, 1.8),
-    target: new THREE.Vector3(0, 2.0, -9.1)
-  },
-  timeline: {
-    name: 'Timeline Gallery',
-    shortName: 'Timeline',
-    center: new THREE.Vector3(13.5, 0, -6.6),
-    overview: new THREE.Vector3(13.5, 3.45, 2.1),
-    target: new THREE.Vector3(13.5, 2.0, -8.8)
-  }
+const ROOMS = {
+  continent: { name: 'Continents', center: new THREE.Vector3(-11, 0, -5.5), overview: new THREE.Vector3(-11, 3.2, 1.8), target: new THREE.Vector3(-11, 2, -7.8) },
+  topic: { name: 'Topics', center: new THREE.Vector3(0, 0, -5.5), overview: new THREE.Vector3(0, 3.2, 1.8), target: new THREE.Vector3(0, 2, -7.8) },
+  timeline: { name: 'Timeline', center: new THREE.Vector3(11, 0, -5.5), overview: new THREE.Vector3(11, 3.2, 1.8), target: new THREE.Vector3(11, 2, -7.8) }
 };
 
-const state = {
-  artworks: [],
-  topicClusters: {},
-  architectureObjects: [],
-  artworkObjects: [],
-  labels: [],
-  artworkLabels: [],
-  displayed: [],
-  selectedIndex: -1,
-  currentGallery: 'continent',
-  cameraGoal: null,
-  renderToken: 0
-};
-
+const state = { artworks: [], topicClusters: {}, roomObjects: [], labels: [], artLabels: [], displayed: [], selectedIndex: -1, currentRoom: 'continent', cameraGoal: null };
 const els = {
-  mount: document.getElementById('exhibitionCanvas'),
-  mode: document.getElementById('exhibitionMode'),
-  topicControl: document.getElementById('topicControl'),
-  topic: document.getElementById('topicSelect'),
-  previous: document.getElementById('previousArtwork'),
-  next: document.getElementById('nextArtwork'),
-  overview: document.getElementById('overviewGallery'),
-  count: document.getElementById('exhibitionCount'),
-  modeLabel: document.getElementById('exhibitionModeLabel'),
-  info: document.getElementById('artworkInfo'),
-  enterContinents: document.getElementById('enterContinents'),
-  enterTopics: document.getElementById('enterTopics'),
-  enterTimeline: document.getElementById('enterTimeline')
+  mount: document.getElementById('exhibitionCanvas'), mode: document.getElementById('exhibitionMode'), topicControl: document.getElementById('topicControl'), topic: document.getElementById('topicSelect'),
+  previous: document.getElementById('previousArtwork'), next: document.getElementById('nextArtwork'), overview: document.getElementById('overviewGallery'), count: document.getElementById('exhibitionCount'), modeLabel: document.getElementById('exhibitionModeLabel'), info: document.getElementById('artworkInfo'),
+  enterContinents: document.getElementById('enterContinents'), enterTopics: document.getElementById('enterTopics'), enterTimeline: document.getElementById('enterTimeline')
 };
 
 const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
-renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.75));
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 renderer.shadowMap.enabled = true;
-renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 renderer.outputColorSpace = THREE.SRGBColorSpace;
 els.mount.appendChild(renderer.domElement);
-
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(0x171512);
-scene.fog = new THREE.Fog(0x171512, 24, 58);
-
-const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 90);
-camera.position.set(0, 4.1, 11.6);
-
+scene.background = new THREE.Color(0xe8ded1);
+scene.fog = new THREE.Fog(0xe8ded1, 22, 48);
+const camera = new THREE.PerspectiveCamera(47, 1, 0.1, 90);
+camera.position.set(0, 3.8, 9.8);
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;
 controls.enablePan = false;
 controls.enableZoom = true;
-controls.minDistance = 3.4;
-controls.maxDistance = 11;
+controls.minDistance = 3.2;
+controls.maxDistance = 10;
 controls.minPolarAngle = Math.PI * 0.31;
-controls.maxPolarAngle = Math.PI * 0.54;
-controls.minAzimuthAngle = -Math.PI * 0.24;
-controls.maxAzimuthAngle = Math.PI * 0.24;
-controls.target.set(0, 1.9, -1.7);
-
+controls.maxPolarAngle = Math.PI * 0.53;
+controls.minAzimuthAngle = -Math.PI * 0.28;
+controls.maxAzimuthAngle = Math.PI * 0.28;
+controls.target.set(0, 1.8, -1.5);
 const raycaster = new THREE.Raycaster();
 const pointer = new THREE.Vector2();
 const clickable = [];
-const selectedFrameMaterial = new THREE.MeshStandardMaterial({
-  color: 0xd9b56a,
-  emissive: 0x5d3a0b,
-  metalness: 0.12,
-  roughness: 0.32
-});
+const highlightMaterial = new THREE.MeshStandardMaterial({ color: 0xd3a44c, emissive: 0x553700, roughness: 0.35 });
 
-function getTitle(artwork) {
-  return artwork.properties?.title || 'Untitled';
+function getTitle(a) { return a.properties?.title || 'Untitled'; }
+function hasThumbnail(a) { return /^https?:\/\//i.test((a.properties?.thumbnail || '').trim()); }
+function topicsFor(a) { return a.properties?.tags?.topic || []; }
+function yearValue(a) { return EcoData.parseYear(a.properties?.year); }
+function byYearAscending(a, b) { const ay = yearValue(a); const by = yearValue(b); if (ay === null && by === null) return getTitle(a).localeCompare(getTitle(b)); if (ay === null) return 1; if (by === null) return -1; return ay - by || getTitle(a).localeCompare(getTitle(b)); }
+function escapeHtml(value) { return String(value).replace(/[&<>'"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[c])); }
+function addTracked(o) { state.roomObjects.push(o); scene.add(o); return o; }
+
+function initEnvironment() {
+  scene.add(new THREE.HemisphereLight(0xfff8e8, 0x7f6b56, 1.55));
+  const wallMat = new THREE.MeshStandardMaterial({ color: 0xf1eadf, roughness: 0.88 });
+  const floorMat = new THREE.MeshStandardMaterial({ color: 0x8b6f55, roughness: 0.72 });
+  const ceilingMat = new THREE.MeshStandardMaterial({ color: 0xe7ded2, roughness: 0.9 });
+  const trimMat = new THREE.MeshStandardMaterial({ color: 0x6f5845, roughness: 0.62 });
+  const addBox = (size, pos, mat) => { const m = new THREE.Mesh(new THREE.BoxGeometry(...size), mat); m.position.set(...pos); m.receiveShadow = true; m.castShadow = true; scene.add(m); return m; };
+  addBox([36, 0.18, 24], [0, 0, -1.6], floorMat);
+  addBox([36, 0.16, 24], [0, 5.1, -1.6], ceilingMat);
+  addBox([36, 5.1, 0.22], [0, 2.55, -13.5], wallMat);
+  addBox([0.22, 5.1, 24], [-18, 2.55, -1.6], wallMat); addBox([0.22, 5.1, 24], [18, 2.55, -1.6], wallMat);
+  addBox([36, 5.1, 0.22], [0, 2.55, 10.3], wallMat);
+  [-5.5, 5.5].forEach((x) => addBox([0.18, 5.1, 15], [x, 2.55, -6], wallMat));
+  [-11, 0, 11].forEach((x) => { addBox([6.8, 5.1, 0.18], [x, 2.55, 1.1], wallMat); addBox([2.2, 0.28, 0.28], [x, 3.55, 1.0], trimMat); });
+  Object.values(ROOMS).forEach((room) => { addSpot(room.center.x - 2.8, 4.75, -4.8, room.center.x, 1.7, -10.8); addSpot(room.center.x + 2.8, 4.75, -4.8, room.center.x, 1.7, -10.8); });
+  addSpot(0, 4.6, 6.5, 0, 1.5, 1.2);
+  createHtmlLabel('Continents', -11, 3.9, 0.85, 'gallery-label--section', true); createHtmlLabel('Topics', 0, 3.9, 0.85, 'gallery-label--section', true); createHtmlLabel('Timeline', 11, 3.9, 0.85, 'gallery-label--section', true);
 }
+function addSpot(x, y, z, tx, ty, tz) { const l = new THREE.SpotLight(0xffead0, 2.6, 20, Math.PI * 0.2, 0.55, 1.35); l.position.set(x, y, z); l.target.position.set(tx, ty, tz); l.castShadow = true; scene.add(l, l.target); }
+function createHtmlLabel(text, x, y, z, className = '', persistent = false) { const label = document.createElement('div'); label.className = `gallery-label ${className}`.trim(); label.textContent = text; els.mount.appendChild(label); state.labels.push(label); if (!persistent) state.artLabels.push(label); label.userData = { position: new THREE.Vector3(x, y, z) }; return label; }
+function textureFor(url) { const loader = new THREE.TextureLoader(); loader.setCrossOrigin('anonymous'); return new Promise((resolve) => { const timer = setTimeout(() => resolve(null), THUMBNAIL_TIMEOUT_MS); loader.load(url, (t) => { clearTimeout(timer); t.colorSpace = THREE.SRGBColorSpace; resolve(t); }, undefined, () => { clearTimeout(timer); resolve(null); }); }); }
 
-function hasThumbnail(artwork) {
-  return /^https?:\/\//i.test((artwork.properties?.thumbnail || '').trim());
-}
+function clearArtworkObjects() { clickable.length = 0; state.roomObjects.forEach((o) => scene.remove(o)); state.roomObjects = []; state.artLabels.forEach((l) => l.remove()); state.labels = state.labels.filter((l) => !state.artLabels.includes(l)); state.artLabels = []; state.displayed = []; state.selectedIndex = -1; }
+function roomSelection(roomKey) { if (roomKey === 'continent') { const groups = new Map(); state.artworks.forEach((a) => { const c = a.properties.continent || 'Other'; if (!groups.has(c)) groups.set(c, []); groups.get(c).push(a); }); return [...groups.keys()].sort().flatMap((c) => groups.get(c).sort(byYearAscending).slice(0, MAX_PER_CONTINENT)).slice(0, MAX_ARTWORKS); } if (roomKey === 'topic') { return state.artworks.filter((a) => (a.properties.clusters || []).includes(els.topic.value) || topicsFor(a).includes(els.topic.value)).sort(byYearAscending).slice(0, MAX_ROOM_ARTWORKS); } return [...state.artworks].sort(byYearAscending).slice(0, MAX_ARTWORKS); }
+function wallSlots(roomKey, count) { const cx = ROOMS[roomKey].center.x; const xs = [-3, 0, 3]; const slots = []; xs.forEach((dx) => slots.push({ x: cx + dx, z: -13.32, ry: 0, label: dx === -3 })); [-9.5, -6.5].forEach((z) => slots.push({ x: cx - 5.38, z, ry: Math.PI / 2 })); [-9.5, -6.5].forEach((z) => slots.push({ x: cx + 5.38, z, ry: -Math.PI / 2 })); [-1.6, 1.6].forEach((dx) => slots.push({ x: cx + dx, z: 0.92, ry: Math.PI })); return slots.slice(0, count); }
+async function addArtwork(artwork, slot, roomKey, index) { const normal = new THREE.Vector3(0, 0, 1).applyAxisAngle(new THREE.Vector3(0, 1, 0), slot.ry); const pos = new THREE.Vector3(slot.x, 2.35, slot.z).addScaledVector(normal, 0.09); const texture = await textureFor(artwork.properties.thumbnail.trim()); const frame = addTracked(new THREE.Mesh(new THREE.BoxGeometry(2.25, 1.72, 0.13), new THREE.MeshStandardMaterial({ color: 0x2d2823, roughness: 0.45 }))); frame.position.copy(pos); frame.rotation.y = slot.ry; frame.userData.defaultMaterial = frame.material; const mat = addTracked(new THREE.Mesh(new THREE.BoxGeometry(2.02, 1.49, 0.05), new THREE.MeshStandardMaterial({ color: 0xf7f1e8, roughness: 0.9 }))); mat.position.copy(pos).addScaledVector(normal, 0.055); mat.rotation.y = slot.ry; const imageMat = texture ? new THREE.MeshBasicMaterial({ map: texture }) : new THREE.MeshBasicMaterial({ color: 0xc9bba9 }); const image = addTracked(new THREE.Mesh(new THREE.PlaneGeometry(1.76, 1.22), imageMat)); image.position.copy(pos).addScaledVector(normal, 0.095); image.rotation.y = slot.ry; image.userData = { artwork, frame, focus: pos.clone().addScaledVector(normal, 3.5).setY(2.25), target: pos.clone() }; clickable.push(image); state.displayed.push({ artwork, object: image, roomKey }); const p = artwork.properties; createHtmlLabel(`${p.title || 'Untitled'}\n${p.artist || 'Unknown'}${p.year ? `, ${p.year}` : ''}`, pos.x, 1.03, pos.z); if (slot.label) createHtmlLabel(ROOMS[roomKey].name, pos.x, 4.35, pos.z, 'gallery-label--section'); }
+async function renderRoom(roomKey) { state.currentRoom = roomKey; els.mode.value = roomKey; els.topicControl.classList.toggle('hidden', roomKey !== 'topic'); els.modeLabel.textContent = ROOMS[roomKey].name; clearArtworkObjects(); const selected = roomSelection(roomKey); els.count.textContent = selected.length; await Promise.all(wallSlots(roomKey, selected.length).map((slot, i) => addArtwork(selected[i], slot, roomKey, i))); focusRoom(roomKey); }
+function populateControls() { const topics = new Set(Object.keys(state.topicClusters)); state.artworks.forEach((a) => topicsFor(a).forEach((t) => topics.add(t))); els.topic.innerHTML = [...topics].sort().map((t) => `<option>${escapeHtml(t)}</option>`).join(''); }
+function showInfo(artwork) { const p = artwork.properties; els.info.innerHTML = `<h2 class="text-xl font-semibold">${escapeHtml(p.title || 'Untitled')}</h2><dl><div><dt>Artist</dt><dd>${escapeHtml(p.artist || 'Unknown')}</dd></div><div><dt>Year</dt><dd>${escapeHtml(p.year || 'Unknown')}</dd></div><div><dt>Continent</dt><dd>${escapeHtml(p.continent || 'Other')}</dd></div><div><dt>Location</dt><dd>${escapeHtml(p.location || 'Unknown')}</dd></div><div><dt>Topics</dt><dd>${escapeHtml(topicsFor(artwork).join(', ') || 'Uncategorized')}</dd></div><div><dt>Description</dt><dd>${escapeHtml((p.description || 'No description available.').slice(0, 240))}${p.description?.length > 240 ? '…' : ''}</dd></div>${p.url ? `<div><dt>Source</dt><dd><a href="${escapeHtml(p.url)}" target="_blank" rel="noopener">Open source link</a></dd></div>` : ''}</dl>`; }
+function applyHighlight() { state.displayed.forEach((item, i) => { item.object.userData.frame.material = i === state.selectedIndex ? highlightMaterial : item.object.userData.frame.userData.defaultMaterial; }); }
+function focusArtwork(index) { if (!state.displayed.length) return; state.selectedIndex = (index + state.displayed.length) % state.displayed.length; const item = state.displayed[state.selectedIndex]; showInfo(item.artwork); applyHighlight(); state.cameraGoal = { position: item.object.userData.focus, target: item.object.userData.target }; }
+function focusRoom(roomKey) { const r = ROOMS[roomKey]; state.cameraGoal = { position: r.overview.clone(), target: r.target.clone() }; }
+function focusOverview() { state.cameraGoal = { position: new THREE.Vector3(0, 3.8, 9.8), target: new THREE.Vector3(0, 1.8, -1.5) }; }
+function onPointerDown(event) { const rect = renderer.domElement.getBoundingClientRect(); pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1; pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1; raycaster.setFromCamera(pointer, camera); const hit = raycaster.intersectObjects(clickable)[0]; if (hit?.object.userData.artwork) focusArtwork(state.displayed.findIndex((i) => i.object === hit.object)); }
+function resize() { const { clientWidth, clientHeight } = els.mount; renderer.setSize(clientWidth, clientHeight, false); camera.aspect = clientWidth / Math.max(clientHeight, 1); camera.updateProjectionMatrix(); }
+function updateLabels() { const w = els.mount.clientWidth; const h = els.mount.clientHeight; state.labels.forEach((label) => { const p = label.userData.position.clone().project(camera); label.style.left = `${(p.x * 0.5 + 0.5) * w}px`; label.style.top = `${(-p.y * 0.5 + 0.5) * h}px`; label.style.display = p.z > 1 || Math.abs(p.x) > 1.15 || Math.abs(p.y) > 1.15 ? 'none' : ''; }); }
+function animate() { requestAnimationFrame(animate); if (state.cameraGoal) { camera.position.lerp(state.cameraGoal.position, 0.09); controls.target.lerp(state.cameraGoal.target, 0.09); if (camera.position.distanceTo(state.cameraGoal.position) < 0.035 && controls.target.distanceTo(state.cameraGoal.target) < 0.035) state.cameraGoal = null; } controls.update(); updateLabels(); renderer.render(scene, camera); }
+async function init() { initEnvironment(); const data = await EcoData.loadSharedData(); state.topicClusters = data.topicClusters; state.artworks = data.artworkData.features.map((a) => EcoData.enrichArtwork(a, data)).filter(hasThumbnail); populateControls(); await renderRoom('continent'); focusOverview(); resize(); animate(); }
 
-function topicsFor(artwork) {
-  return artwork.properties?.tags?.topic || [];
-}
-
-function yearValue(artwork) {
-  return EcoData.parseYear(artwork.properties?.year);
-}
-
-function byYearAscending(a, b) {
-  const ay = yearValue(a);
-  const by = yearValue(b);
-  if (ay === null && by === null) return getTitle(a).localeCompare(getTitle(b));
-  if (ay === null) return 1;
-  if (by === null) return -1;
-  return ay - by || getTitle(a).localeCompare(getTitle(b));
-}
-
-function escapeHtml(value) {
-  return String(value).replace(/[&<>'"]/g, (char) => ({
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    "'": '&#39;',
-    '"': '&quot;'
-  }[char]));
-}
-
-function hashString(value) {
-  let hash = 2166136261;
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-  return hash >>> 0;
-}
-
-function seededRandom(seed) {
-  let value = seed >>> 0;
-  return () => {
-    value += 0x6d2b79f5;
-    let next = value;
-    next = Math.imul(next ^ (next >>> 15), next | 1);
-    next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
-    return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-function monthlyRotate(items, key) {
-  const random = seededRandom(hashString(`${MONTH_SEED}:${key}`));
-  return [...items]
-    .map((item) => ({ item, rank: random() }))
-    .sort((a, b) => a.rank - b.rank)
-    .map(({ item }) => item);
-}
-
-function trackArchitecture(object) {
-  state.architectureObjects.push(object);
-  scene.add(object);
-  return object;
-}
-
-function trackArtwork(object) {
-  state.artworkObjects.push(object);
-  scene.add(object);
-  return object;
-}
-
-function addBox({ size, position, material, castShadow = true, receiveShadow = true }) {
-  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), material);
-  mesh.position.set(...position);
-  mesh.castShadow = castShadow;
-  mesh.receiveShadow = receiveShadow;
-  return trackArchitecture(mesh);
-}
-
-function initArchitecture() {
-  const wallMaterial = new THREE.MeshStandardMaterial({ color: 0xeee5d8, roughness: 0.86 });
-  const sideWallMaterial = new THREE.MeshStandardMaterial({ color: 0xe2d7ca, roughness: 0.88 });
-  const floorMaterial = new THREE.MeshStandardMaterial({ color: 0x5f5145, roughness: 0.68, metalness: 0.03 });
-  const ceilingMaterial = new THREE.MeshStandardMaterial({ color: 0xd9d0c4, roughness: 0.9 });
-  const darkTrimMaterial = new THREE.MeshStandardMaterial({ color: 0x25221e, roughness: 0.42, metalness: 0.14 });
-  const brassMaterial = new THREE.MeshStandardMaterial({ color: 0xb99655, roughness: 0.36, metalness: 0.35 });
-  const glowMaterial = new THREE.MeshBasicMaterial({ color: 0xf6dca7, transparent: true, opacity: 0.46 });
-
-  scene.add(new THREE.HemisphereLight(0xfff3dd, 0x322a24, 1.45));
-  scene.add(new THREE.AmbientLight(0xffead2, 0.55));
-
-  addBox({ size: [44, 0.2, 31], position: [0, 0, -3.4], material: floorMaterial, castShadow: false });
-  addBox({ size: [44, 0.18, 31], position: [0, 5.65, -3.4], material: ceilingMaterial, castShadow: false });
-
-  addBox({ size: [44, 5.65, 0.28], position: [0, 2.82, -18.9], material: wallMaterial });
-  addBox({ size: [44, 5.65, 0.28], position: [0, 2.82, 12.1], material: sideWallMaterial });
-  addBox({ size: [0.28, 5.65, 31], position: [-22, 2.82, -3.4], material: sideWallMaterial });
-  addBox({ size: [0.28, 5.65, 31], position: [22, 2.82, -3.4], material: sideWallMaterial });
-
-  [-7.2, 7.2].forEach((x) => {
-    addBox({ size: [0.22, 5.65, 19.5], position: [x, 2.82, -8.2], material: wallMaterial });
-    addBox({ size: [0.42, 0.22, 19.5], position: [x, 5.55, -8.2], material: darkTrimMaterial });
-  });
-
-  [-13.5, 0, 13.5].forEach((x) => {
-    addBox({ size: [8.7, 5.65, 0.24], position: [x, 2.82, 1.55], material: wallMaterial });
-    addBox({ size: [3.0, 0.34, 0.36], position: [x, 3.72, 1.36], material: brassMaterial });
-    addBox({ size: [0.08, 4.6, 0.08], position: [x - 4.25, 2.55, 1.18], material: darkTrimMaterial });
-    addBox({ size: [0.08, 4.6, 0.08], position: [x + 4.25, 2.55, 1.18], material: darkTrimMaterial });
-  });
-
-  addBox({ size: [14, 0.06, 0.12], position: [0, 0.05, 5.4], material: glowMaterial, castShadow: false, receiveShadow: false });
-  addBox({ size: [36, 0.06, 0.12], position: [0, 0.06, -3.5], material: glowMaterial, castShadow: false, receiveShadow: false });
-
-  Object.values(GALLERIES).forEach((gallery) => {
-    addSpotlight(gallery.center.x - 3.0, 5.25, -6.0, gallery.center.x - 2.0, 1.85, -17.7, 2.2);
-    addSpotlight(gallery.center.x + 3.0, 5.25, -6.0, gallery.center.x + 2.0, 1.85, -17.7, 2.2);
-    addSpotlight(gallery.center.x, 5.35, -1.1, gallery.center.x, 1.75, -7.6, 1.4);
-  });
-  addSpotlight(0, 5.2, 7.4, 0, 1.6, 1.2, 1.6);
-
-  createLabel('Continent Gallery', -13.5, 4.1, 1.2, 'gallery-label--room', true);
-  createLabel('Topic Gallery', 0, 4.1, 1.2, 'gallery-label--room', true);
-  createLabel('Timeline Gallery', 13.5, 4.1, 1.2, 'gallery-label--room', true);
-}
-
-function addSpotlight(x, y, z, targetX, targetY, targetZ, intensity) {
-  const light = new THREE.SpotLight(0xffe6c2, intensity, 23, Math.PI * 0.16, 0.58, 1.3);
-  light.position.set(x, y, z);
-  light.target.position.set(targetX, targetY, targetZ);
-  light.castShadow = true;
-  light.shadow.mapSize.set(512, 512);
-  scene.add(light, light.target);
-}
-
-function createLabel(text, x, y, z, className = '', persistent = false) {
-  const label = document.createElement('div');
-  label.className = `gallery-label ${className}`.trim();
-  label.textContent = text;
-  label.userData = { position: new THREE.Vector3(x, y, z) };
-  els.mount.appendChild(label);
-  state.labels.push(label);
-  if (!persistent) state.artworkLabels.push(label);
-  return label;
-}
-
-function textureFor(url) {
-  const loader = new THREE.TextureLoader();
-  loader.setCrossOrigin('anonymous');
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => resolve(null), THUMBNAIL_TIMEOUT_MS);
-    loader.load(
-      url,
-      (texture) => {
-        clearTimeout(timer);
-        texture.colorSpace = THREE.SRGBColorSpace;
-        resolve(texture);
-      },
-      undefined,
-      () => {
-        clearTimeout(timer);
-        resolve(null);
-      }
-    );
-  });
-}
-
-function clearArtworkDisplay() {
-  clickable.length = 0;
-  state.artworkObjects.forEach((object) => scene.remove(object));
-  state.artworkObjects = [];
-  state.artworkLabels.forEach((label) => label.remove());
-  state.labels = state.labels.filter((label) => !state.artworkLabels.includes(label));
-  state.artworkLabels = [];
-  state.displayed = [];
-  state.selectedIndex = -1;
-}
-
-function selectForGallery(galleryKey) {
-  if (galleryKey === 'continent') {
-    const groups = new Map();
-    state.artworks.forEach((artwork) => {
-      const continent = artwork.properties.continent || 'Other';
-      if (!groups.has(continent)) groups.set(continent, []);
-      groups.get(continent).push(artwork);
-    });
-
-    return [...groups.keys()].sort().flatMap((continent) => (
-      monthlyRotate(groups.get(continent), `continent:${continent}`)
-        .slice(0, MAX_PER_CONTINENT)
-        .sort(byYearAscending)
-    )).slice(0, MAX_TOTAL_ARTWORKS);
-  }
-
-  if (galleryKey === 'topic') {
-    return monthlyRotate(
-      state.artworks.filter((artwork) => (
-        (artwork.properties.clusters || []).includes(els.topic.value) || topicsFor(artwork).includes(els.topic.value)
-      )),
-      `topic:${els.topic.value}`
-    ).slice(0, MAX_TOPIC_ARTWORKS).sort(byYearAscending);
-  }
-
-  return monthlyRotate(state.artworks, 'timeline')
-    .slice(0, MAX_TOTAL_ARTWORKS)
-    .sort(byYearAscending);
-}
-
-function slotsForGallery(galleryKey, count) {
-  const centerX = GALLERIES[galleryKey].center.x;
-  const slots = [];
-
-  [-4.2, -1.4, 1.4, 4.2].forEach((offsetX) => {
-    slots.push({ x: centerX + offsetX, z: -18.68, rotationY: 0 });
-  });
-
-  [-15.4, -12.5, -9.6, -6.7].forEach((z) => {
-    slots.push({ x: centerX - 6.95, z, rotationY: Math.PI / 2 });
-  });
-
-  [-15.4, -12.5, -9.6, -6.7].forEach((z) => {
-    slots.push({ x: centerX + 6.95, z, rotationY: -Math.PI / 2 });
-  });
-
-  [-3.1, 0, 3.1].forEach((offsetX) => {
-    slots.push({ x: centerX + offsetX, z: 1.34, rotationY: Math.PI });
-  });
-
-  return slots.slice(0, count);
-}
-
-async function addArtwork(artwork, slot) {
-  const normal = new THREE.Vector3(0, 0, 1).applyAxisAngle(new THREE.Vector3(0, 1, 0), slot.rotationY);
-  const wallPosition = new THREE.Vector3(slot.x, 2.42, slot.z).addScaledVector(normal, 0.1);
-  const texture = await textureFor(artwork.properties.thumbnail.trim());
-
-  const frameMaterial = new THREE.MeshStandardMaterial({ color: 0x211f1c, roughness: 0.38, metalness: 0.12 });
-  const frame = trackArtwork(new THREE.Mesh(new THREE.BoxGeometry(2.28, 1.76, 0.14), frameMaterial));
-  frame.position.copy(wallPosition);
-  frame.rotation.y = slot.rotationY;
-  frame.castShadow = true;
-  frame.userData.defaultMaterial = frameMaterial;
-
-  const matBoard = trackArtwork(new THREE.Mesh(
-    new THREE.BoxGeometry(2.02, 1.5, 0.05),
-    new THREE.MeshStandardMaterial({ color: 0xf8f1e7, roughness: 0.92 })
-  ));
-  matBoard.position.copy(wallPosition).addScaledVector(normal, 0.055);
-  matBoard.rotation.y = slot.rotationY;
-
-  const imageMaterial = texture
-    ? new THREE.MeshBasicMaterial({ map: texture })
-    : new THREE.MeshBasicMaterial({ color: 0xb9aa98 });
-  const image = trackArtwork(new THREE.Mesh(new THREE.PlaneGeometry(1.78, 1.24), imageMaterial));
-  image.position.copy(wallPosition).addScaledVector(normal, 0.095);
-  image.rotation.y = slot.rotationY;
-  image.userData = {
-    artwork,
-    frame,
-    focus: wallPosition.clone().addScaledVector(normal, 3.45).setY(2.35),
-    target: wallPosition.clone()
-  };
-
-  clickable.push(image);
-  state.displayed.push({ artwork, object: image });
-
-  const props = artwork.properties;
-  createLabel(
-    `${props.title || 'Untitled'}\n${props.artist || 'Unknown'}${props.year ? `, ${props.year}` : ''}`,
-    wallPosition.x,
-    1.05,
-    wallPosition.z
-  );
-}
-
-async function renderGallery(galleryKey) {
-  const token = state.renderToken + 1;
-  state.renderToken = token;
-  state.currentGallery = galleryKey;
-  els.mode.value = galleryKey;
-  els.topicControl.classList.toggle('hidden', galleryKey !== 'topic');
-  els.modeLabel.textContent = GALLERIES[galleryKey].name;
-  clearArtworkDisplay();
-
-  const selection = selectForGallery(galleryKey);
-  const slots = slotsForGallery(galleryKey, selection.length);
-  els.count.textContent = slots.length;
-
-  for (let index = 0; index < slots.length; index += 1) {
-    if (state.renderToken !== token) return;
-    await addArtwork(selection[index], slots[index]);
-  }
-
-  focusGallery(galleryKey);
-}
-
-function populateTopicControl() {
-  const topics = new Set(Object.keys(state.topicClusters));
-  state.artworks.forEach((artwork) => topicsFor(artwork).forEach((topic) => topics.add(topic)));
-  els.topic.innerHTML = [...topics].sort().map((topic) => `<option>${escapeHtml(topic)}</option>`).join('');
-}
-
-function showInfo(artwork) {
-  const props = artwork.properties;
-  els.info.innerHTML = `<h2 class="text-xl font-semibold">${escapeHtml(props.title || 'Untitled')}</h2><dl>
-    <div><dt>Artist</dt><dd>${escapeHtml(props.artist || 'Unknown')}</dd></div>
-    <div><dt>Year</dt><dd>${escapeHtml(props.year || 'Unknown')}</dd></div>
-    <div><dt>Continent</dt><dd>${escapeHtml(props.continent || 'Other')}</dd></div>
-    <div><dt>Location</dt><dd>${escapeHtml(props.location || 'Unknown')}</dd></div>
-    <div><dt>Topics</dt><dd>${escapeHtml(topicsFor(artwork).join(', ') || 'Uncategorized')}</dd></div>
-    <div><dt>Description</dt><dd>${escapeHtml((props.description || 'No description available.').slice(0, 240))}${props.description?.length > 240 ? '…' : ''}</dd></div>
-    ${props.url ? `<div><dt>Source</dt><dd><a href="${escapeHtml(props.url)}" target="_blank" rel="noopener">Open source link</a></dd></div>` : ''}
-  </dl>`;
-}
-
-function updateSelectionHighlight() {
-  state.displayed.forEach((item, index) => {
-    const frame = item.object.userData.frame;
-    frame.material = index === state.selectedIndex ? selectedFrameMaterial : frame.userData.defaultMaterial;
-  });
-}
-
-function focusArtwork(index) {
-  if (!state.displayed.length) return;
-  state.selectedIndex = (index + state.displayed.length) % state.displayed.length;
-  const item = state.displayed[state.selectedIndex];
-  showInfo(item.artwork);
-  updateSelectionHighlight();
-  state.cameraGoal = {
-    position: item.object.userData.focus,
-    target: item.object.userData.target
-  };
-}
-
-function focusGallery(galleryKey) {
-  const gallery = GALLERIES[galleryKey];
-  state.cameraGoal = {
-    position: gallery.overview.clone(),
-    target: gallery.target.clone()
-  };
-}
-
-function focusEntrance() {
-  els.modeLabel.textContent = 'Entrance';
-  state.cameraGoal = {
-    position: new THREE.Vector3(0, 4.1, 11.6),
-    target: new THREE.Vector3(0, 1.9, -1.7)
-  };
-}
-
-function onPointerDown(event) {
-  const rect = renderer.domElement.getBoundingClientRect();
-  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
-  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
-  raycaster.setFromCamera(pointer, camera);
-  const hit = raycaster.intersectObjects(clickable)[0];
-  if (hit?.object.userData.artwork) {
-    focusArtwork(state.displayed.findIndex((item) => item.object === hit.object));
-  }
-}
-
-function resize() {
-  const { clientWidth, clientHeight } = els.mount;
-  renderer.setSize(clientWidth, clientHeight, false);
-  camera.aspect = clientWidth / Math.max(clientHeight, 1);
-  camera.updateProjectionMatrix();
-}
-
-function updateLabels() {
-  const width = els.mount.clientWidth;
-  const height = els.mount.clientHeight;
-  state.labels.forEach((label) => {
-    const projected = label.userData.position.clone().project(camera);
-    label.style.left = `${(projected.x * 0.5 + 0.5) * width}px`;
-    label.style.top = `${(-projected.y * 0.5 + 0.5) * height}px`;
-    label.style.display = projected.z > 1 || Math.abs(projected.x) > 1.12 || Math.abs(projected.y) > 1.12 ? 'none' : '';
-  });
-}
-
-function animate() {
-  requestAnimationFrame(animate);
-  if (state.cameraGoal) {
-    camera.position.lerp(state.cameraGoal.position, 0.085);
-    controls.target.lerp(state.cameraGoal.target, 0.085);
-    if (camera.position.distanceTo(state.cameraGoal.position) < 0.035 && controls.target.distanceTo(state.cameraGoal.target) < 0.035) {
-      state.cameraGoal = null;
-    }
-  }
-  controls.update();
-  updateLabels();
-  renderer.render(scene, camera);
-}
-
-async function init() {
-  initArchitecture();
-  const data = await EcoData.loadSharedData();
-  state.topicClusters = data.topicClusters;
-  state.artworks = data.artworkData.features
-    .map((artwork) => EcoData.enrichArtwork(artwork, data))
-    .filter(hasThumbnail);
-
-  populateTopicControl();
-  await renderGallery('continent');
-  focusEntrance();
-  resize();
-  animate();
-}
-
-els.mode.addEventListener('change', () => renderGallery(els.mode.value));
-els.topic.addEventListener('change', () => renderGallery('topic'));
-els.enterContinents.addEventListener('click', () => renderGallery('continent'));
-els.enterTopics.addEventListener('click', () => renderGallery('topic'));
-els.enterTimeline.addEventListener('click', () => renderGallery('timeline'));
+els.mode.addEventListener('change', () => renderRoom(els.mode.value));
+els.topic.addEventListener('change', () => renderRoom('topic'));
+els.enterContinents.addEventListener('click', () => renderRoom('continent'));
+els.enterTopics.addEventListener('click', () => renderRoom('topic'));
+els.enterTimeline.addEventListener('click', () => renderRoom('timeline'));
 els.previous.addEventListener('click', () => focusArtwork(state.selectedIndex - 1));
 els.next.addEventListener('click', () => focusArtwork(state.selectedIndex + 1));
-els.overview.addEventListener('click', focusEntrance);
+els.overview.addEventListener('click', focusOverview);
 renderer.domElement.addEventListener('pointerdown', onPointerDown);
 window.addEventListener('resize', resize);
-
-init().catch((error) => {
-  els.info.innerHTML = `<h2 class="text-xl font-semibold">Exhibition unavailable</h2><p class="mt-2 text-sm opacity-75">${escapeHtml(error.message)}</p>`;
-  console.error(error);
-});
+init().catch((error) => { els.info.innerHTML = `<h2 class="text-xl font-semibold">Exhibition unavailable</h2><p class="mt-2 text-sm opacity-75">${escapeHtml(error.message)}</p>`; console.error(error); });

--- a/assets/js/exhibition.js
+++ b/assets/js/exhibition.js
@@ -3,17 +3,48 @@ import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.165.0/exampl
 
 const EcoData = window.EcoData;
 
-const MAX_ARTWORKS = 28;
-const MAX_PER_CONTINENT = 5;
-const THUMBNAIL_TIMEOUT_MS = 8000;
+const MAX_TOTAL_ARTWORKS = 56;
+const MAX_PER_CONTINENT = 8;
+const MAX_TOPIC_ARTWORKS = 18;
+const THUMBNAIL_TIMEOUT_MS = 6500;
+const MONTH_SEED = new Date().toISOString().slice(0, 7);
+
+const GALLERIES = {
+  continent: {
+    name: 'Continent Gallery',
+    shortName: 'Continent',
+    center: new THREE.Vector3(-13.5, 0, -6.6),
+    overview: new THREE.Vector3(-13.5, 3.45, 2.1),
+    target: new THREE.Vector3(-13.5, 2.0, -8.8)
+  },
+  topic: {
+    name: 'Topic Gallery',
+    shortName: 'Topic',
+    center: new THREE.Vector3(0, 0, -7.2),
+    overview: new THREE.Vector3(0, 3.55, 1.8),
+    target: new THREE.Vector3(0, 2.0, -9.1)
+  },
+  timeline: {
+    name: 'Timeline Gallery',
+    shortName: 'Timeline',
+    center: new THREE.Vector3(13.5, 0, -6.6),
+    overview: new THREE.Vector3(13.5, 3.45, 2.1),
+    target: new THREE.Vector3(13.5, 2.0, -8.8)
+  }
+};
+
 const state = {
   artworks: [],
   topicClusters: {},
-  sceneObjects: [],
+  architectureObjects: [],
+  artworkObjects: [],
   labels: [],
+  artworkLabels: [],
   displayed: [],
   selectedIndex: -1,
-  cameraGoal: null
+  currentGallery: 'continent',
+  cameraGoal: null,
+  renderToken: 0
 };
 
 const els = {
@@ -26,113 +57,195 @@ const els = {
   overview: document.getElementById('overviewGallery'),
   count: document.getElementById('exhibitionCount'),
   modeLabel: document.getElementById('exhibitionModeLabel'),
-  info: document.getElementById('artworkInfo')
+  info: document.getElementById('artworkInfo'),
+  enterContinents: document.getElementById('enterContinents'),
+  enterTopics: document.getElementById('enterTopics'),
+  enterTimeline: document.getElementById('enterTimeline')
 };
 
-const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.75));
 renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 renderer.outputColorSpace = THREE.SRGBColorSpace;
 els.mount.appendChild(renderer.domElement);
 
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(0xeee6da);
-scene.fog = new THREE.Fog(0xeee6da, 24, 58);
+scene.background = new THREE.Color(0x171512);
+scene.fog = new THREE.Fog(0x171512, 24, 58);
 
-const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 120);
-camera.position.set(0, 4.2, 15.5);
+const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 90);
+camera.position.set(0, 4.1, 11.6);
+
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;
 controls.enablePan = false;
-controls.minPolarAngle = Math.PI * 0.28;
-controls.maxPolarAngle = Math.PI * 0.48;
-controls.minAzimuthAngle = -Math.PI * 0.45;
-controls.maxAzimuthAngle = Math.PI * 0.45;
-controls.minDistance = 6;
-controls.maxDistance = 19;
-controls.target.set(0, 1.8, -2.4);
+controls.enableZoom = true;
+controls.minDistance = 3.4;
+controls.maxDistance = 11;
+controls.minPolarAngle = Math.PI * 0.31;
+controls.maxPolarAngle = Math.PI * 0.54;
+controls.minAzimuthAngle = -Math.PI * 0.24;
+controls.maxAzimuthAngle = Math.PI * 0.24;
+controls.target.set(0, 1.9, -1.7);
 
 const raycaster = new THREE.Raycaster();
 const pointer = new THREE.Vector2();
 const clickable = [];
+const selectedFrameMaterial = new THREE.MeshStandardMaterial({
+  color: 0xd9b56a,
+  emissive: 0x5d3a0b,
+  metalness: 0.12,
+  roughness: 0.32
+});
+
+function getTitle(artwork) {
+  return artwork.properties?.title || 'Untitled';
+}
+
+function hasThumbnail(artwork) {
+  return /^https?:\/\//i.test((artwork.properties?.thumbnail || '').trim());
+}
+
+function topicsFor(artwork) {
+  return artwork.properties?.tags?.topic || [];
+}
+
+function yearValue(artwork) {
+  return EcoData.parseYear(artwork.properties?.year);
+}
 
 function byYearAscending(a, b) {
-  const ay = EcoData.parseYear(a.properties?.year);
-  const by = EcoData.parseYear(b.properties?.year);
+  const ay = yearValue(a);
+  const by = yearValue(b);
   if (ay === null && by === null) return getTitle(a).localeCompare(getTitle(b));
   if (ay === null) return 1;
   if (by === null) return -1;
   return ay - by || getTitle(a).localeCompare(getTitle(b));
 }
 
-function getTitle(artwork) { return artwork.properties?.title || 'Untitled'; }
-function hasThumbnail(artwork) { return /^https?:\/\//i.test((artwork.properties?.thumbnail || '').trim()); }
-function topicsFor(artwork) { return artwork.properties?.tags?.topic || []; }
-
-function initEnvironment() {
-  scene.add(new THREE.HemisphereLight(0xfffbef, 0x97836b, 1.4));
-  addSpotLight(-6.5, 7.5, 2, -4, 1.7, -7);
-  addSpotLight(0, 7.8, 1.5, 0, 1.7, -8);
-  addSpotLight(6.5, 7.5, 2, 4, 1.7, -7);
-
-  const wallMaterial = new THREE.MeshStandardMaterial({ color: 0xf4eee4, roughness: 0.86 });
-  const floorMaterial = new THREE.MeshStandardMaterial({ color: 0xb59a79, roughness: 0.78 });
-  const backWall = new THREE.Mesh(new THREE.BoxGeometry(36, 7.2, 0.28), wallMaterial);
-  backWall.position.set(0, 3.6, -10.5);
-  const leftWall = new THREE.Mesh(new THREE.BoxGeometry(0.28, 7.2, 24), wallMaterial);
-  leftWall.position.set(-18, 3.6, 1.2);
-  const rightWall = leftWall.clone();
-  rightWall.position.x = 18;
-  const floor = new THREE.Mesh(new THREE.PlaneGeometry(38, 28), floorMaterial);
-  floor.rotation.x = -Math.PI / 2;
-  floor.position.z = 1.5;
-  [backWall, leftWall, rightWall, floor].forEach((object) => {
-    object.receiveShadow = true;
-    scene.add(object);
-  });
-
-  const ceilingGlow = new THREE.Mesh(new THREE.PlaneGeometry(34, 9), new THREE.MeshBasicMaterial({ color: 0xfff5df, transparent: true, opacity: 0.14 }));
-  ceilingGlow.rotation.x = Math.PI / 2;
-  ceilingGlow.position.set(0, 7.18, -3);
-  scene.add(ceilingGlow);
+function escapeHtml(value) {
+  return String(value).replace(/[&<>'"]/g, (char) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    "'": '&#39;',
+    '"': '&quot;'
+  }[char]));
 }
 
-function addSpotLight(x, y, z, tx, ty, tz) {
-  const light = new THREE.SpotLight(0xffead0, 2.8, 26, Math.PI * 0.18, 0.6, 1.4);
+function hashString(value) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function seededRandom(seed) {
+  let value = seed >>> 0;
+  return () => {
+    value += 0x6d2b79f5;
+    let next = value;
+    next = Math.imul(next ^ (next >>> 15), next | 1);
+    next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+    return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function monthlyRotate(items, key) {
+  const random = seededRandom(hashString(`${MONTH_SEED}:${key}`));
+  return [...items]
+    .map((item) => ({ item, rank: random() }))
+    .sort((a, b) => a.rank - b.rank)
+    .map(({ item }) => item);
+}
+
+function trackArchitecture(object) {
+  state.architectureObjects.push(object);
+  scene.add(object);
+  return object;
+}
+
+function trackArtwork(object) {
+  state.artworkObjects.push(object);
+  scene.add(object);
+  return object;
+}
+
+function addBox({ size, position, material, castShadow = true, receiveShadow = true }) {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), material);
+  mesh.position.set(...position);
+  mesh.castShadow = castShadow;
+  mesh.receiveShadow = receiveShadow;
+  return trackArchitecture(mesh);
+}
+
+function initArchitecture() {
+  const wallMaterial = new THREE.MeshStandardMaterial({ color: 0xeee5d8, roughness: 0.86 });
+  const sideWallMaterial = new THREE.MeshStandardMaterial({ color: 0xe2d7ca, roughness: 0.88 });
+  const floorMaterial = new THREE.MeshStandardMaterial({ color: 0x5f5145, roughness: 0.68, metalness: 0.03 });
+  const ceilingMaterial = new THREE.MeshStandardMaterial({ color: 0xd9d0c4, roughness: 0.9 });
+  const darkTrimMaterial = new THREE.MeshStandardMaterial({ color: 0x25221e, roughness: 0.42, metalness: 0.14 });
+  const brassMaterial = new THREE.MeshStandardMaterial({ color: 0xb99655, roughness: 0.36, metalness: 0.35 });
+  const glowMaterial = new THREE.MeshBasicMaterial({ color: 0xf6dca7, transparent: true, opacity: 0.46 });
+
+  scene.add(new THREE.HemisphereLight(0xfff3dd, 0x322a24, 1.45));
+  scene.add(new THREE.AmbientLight(0xffead2, 0.55));
+
+  addBox({ size: [44, 0.2, 31], position: [0, 0, -3.4], material: floorMaterial, castShadow: false });
+  addBox({ size: [44, 0.18, 31], position: [0, 5.65, -3.4], material: ceilingMaterial, castShadow: false });
+
+  addBox({ size: [44, 5.65, 0.28], position: [0, 2.82, -18.9], material: wallMaterial });
+  addBox({ size: [44, 5.65, 0.28], position: [0, 2.82, 12.1], material: sideWallMaterial });
+  addBox({ size: [0.28, 5.65, 31], position: [-22, 2.82, -3.4], material: sideWallMaterial });
+  addBox({ size: [0.28, 5.65, 31], position: [22, 2.82, -3.4], material: sideWallMaterial });
+
+  [-7.2, 7.2].forEach((x) => {
+    addBox({ size: [0.22, 5.65, 19.5], position: [x, 2.82, -8.2], material: wallMaterial });
+    addBox({ size: [0.42, 0.22, 19.5], position: [x, 5.55, -8.2], material: darkTrimMaterial });
+  });
+
+  [-13.5, 0, 13.5].forEach((x) => {
+    addBox({ size: [8.7, 5.65, 0.24], position: [x, 2.82, 1.55], material: wallMaterial });
+    addBox({ size: [3.0, 0.34, 0.36], position: [x, 3.72, 1.36], material: brassMaterial });
+    addBox({ size: [0.08, 4.6, 0.08], position: [x - 4.25, 2.55, 1.18], material: darkTrimMaterial });
+    addBox({ size: [0.08, 4.6, 0.08], position: [x + 4.25, 2.55, 1.18], material: darkTrimMaterial });
+  });
+
+  addBox({ size: [14, 0.06, 0.12], position: [0, 0.05, 5.4], material: glowMaterial, castShadow: false, receiveShadow: false });
+  addBox({ size: [36, 0.06, 0.12], position: [0, 0.06, -3.5], material: glowMaterial, castShadow: false, receiveShadow: false });
+
+  Object.values(GALLERIES).forEach((gallery) => {
+    addSpotlight(gallery.center.x - 3.0, 5.25, -6.0, gallery.center.x - 2.0, 1.85, -17.7, 2.2);
+    addSpotlight(gallery.center.x + 3.0, 5.25, -6.0, gallery.center.x + 2.0, 1.85, -17.7, 2.2);
+    addSpotlight(gallery.center.x, 5.35, -1.1, gallery.center.x, 1.75, -7.6, 1.4);
+  });
+  addSpotlight(0, 5.2, 7.4, 0, 1.6, 1.2, 1.6);
+
+  createLabel('Continent Gallery', -13.5, 4.1, 1.2, 'gallery-label--room', true);
+  createLabel('Topic Gallery', 0, 4.1, 1.2, 'gallery-label--room', true);
+  createLabel('Timeline Gallery', 13.5, 4.1, 1.2, 'gallery-label--room', true);
+}
+
+function addSpotlight(x, y, z, targetX, targetY, targetZ, intensity) {
+  const light = new THREE.SpotLight(0xffe6c2, intensity, 23, Math.PI * 0.16, 0.58, 1.3);
   light.position.set(x, y, z);
-  light.target.position.set(tx, ty, tz);
+  light.target.position.set(targetX, targetY, targetZ);
   light.castShadow = true;
+  light.shadow.mapSize.set(512, 512);
   scene.add(light, light.target);
 }
 
-function clearExhibition() {
-  clickable.length = 0;
-  state.sceneObjects.forEach((object) => scene.remove(object));
-  state.labels.forEach((label) => label.remove());
-  state.sceneObjects = [];
-  state.labels = [];
-  state.displayed = [];
-  state.selectedIndex = -1;
-}
-
-function addTracked(object) { state.sceneObjects.push(object); scene.add(object); return object; }
-
-function createWallSection(x, z, rotationY, width = 5.6, label = '') {
-  const panel = addTracked(new THREE.Mesh(new THREE.BoxGeometry(width, 3.75, 0.2), new THREE.MeshStandardMaterial({ color: 0xf8f4ec, roughness: 0.82 })));
-  panel.position.set(x, 2.28, z);
-  panel.rotation.y = rotationY;
-  panel.receiveShadow = true;
-  if (label) createHtmlLabel(label, x, 4.45, z, 'gallery-label--section');
-  return panel;
-}
-
-function createHtmlLabel(text, x, y, z, className = '') {
+function createLabel(text, x, y, z, className = '', persistent = false) {
   const label = document.createElement('div');
   label.className = `gallery-label ${className}`.trim();
   label.textContent = text;
+  label.userData = { position: new THREE.Vector3(x, y, z) };
   els.mount.appendChild(label);
   state.labels.push(label);
-  label.userData = { position: new THREE.Vector3(x, y, z) };
+  if (!persistent) state.artworkLabels.push(label);
   return label;
 }
 
@@ -141,114 +254,175 @@ function textureFor(url) {
   loader.setCrossOrigin('anonymous');
   return new Promise((resolve) => {
     const timer = setTimeout(() => resolve(null), THUMBNAIL_TIMEOUT_MS);
-    loader.load(url, (texture) => { clearTimeout(timer); texture.colorSpace = THREE.SRGBColorSpace; resolve(texture); }, undefined, () => { clearTimeout(timer); resolve(null); });
+    loader.load(
+      url,
+      (texture) => {
+        clearTimeout(timer);
+        texture.colorSpace = THREE.SRGBColorSpace;
+        resolve(texture);
+      },
+      undefined,
+      () => {
+        clearTimeout(timer);
+        resolve(null);
+      }
+    );
   });
 }
 
-async function addArtwork(artwork, x, z, rotationY, sectionLabel = '') {
-  createWallSection(x, z, rotationY, 4.6, sectionLabel);
-  const normal = new THREE.Vector3(0, 0, 1).applyAxisAngle(new THREE.Vector3(0, 1, 0), rotationY);
-  const artPos = new THREE.Vector3(x, 2.35, z).addScaledVector(normal, 0.14);
-  const texture = await textureFor(artwork.properties.thumbnail.trim());
-  if (!texture) return;
+function clearArtworkDisplay() {
+  clickable.length = 0;
+  state.artworkObjects.forEach((object) => scene.remove(object));
+  state.artworkObjects = [];
+  state.artworkLabels.forEach((label) => label.remove());
+  state.labels = state.labels.filter((label) => !state.artworkLabels.includes(label));
+  state.artworkLabels = [];
+  state.displayed = [];
+  state.selectedIndex = -1;
+}
 
-  const frame = addTracked(new THREE.Mesh(new THREE.BoxGeometry(2.28, 1.76, 0.16), new THREE.MeshStandardMaterial({ color: 0x2e2822, metalness: 0.08, roughness: 0.48 })));
-  frame.position.copy(artPos);
-  frame.rotation.y = rotationY;
+function selectForGallery(galleryKey) {
+  if (galleryKey === 'continent') {
+    const groups = new Map();
+    state.artworks.forEach((artwork) => {
+      const continent = artwork.properties.continent || 'Other';
+      if (!groups.has(continent)) groups.set(continent, []);
+      groups.get(continent).push(artwork);
+    });
+
+    return [...groups.keys()].sort().flatMap((continent) => (
+      monthlyRotate(groups.get(continent), `continent:${continent}`)
+        .slice(0, MAX_PER_CONTINENT)
+        .sort(byYearAscending)
+    )).slice(0, MAX_TOTAL_ARTWORKS);
+  }
+
+  if (galleryKey === 'topic') {
+    return monthlyRotate(
+      state.artworks.filter((artwork) => (
+        (artwork.properties.clusters || []).includes(els.topic.value) || topicsFor(artwork).includes(els.topic.value)
+      )),
+      `topic:${els.topic.value}`
+    ).slice(0, MAX_TOPIC_ARTWORKS).sort(byYearAscending);
+  }
+
+  return monthlyRotate(state.artworks, 'timeline')
+    .slice(0, MAX_TOTAL_ARTWORKS)
+    .sort(byYearAscending);
+}
+
+function slotsForGallery(galleryKey, count) {
+  const centerX = GALLERIES[galleryKey].center.x;
+  const slots = [];
+
+  [-4.2, -1.4, 1.4, 4.2].forEach((offsetX) => {
+    slots.push({ x: centerX + offsetX, z: -18.68, rotationY: 0 });
+  });
+
+  [-15.4, -12.5, -9.6, -6.7].forEach((z) => {
+    slots.push({ x: centerX - 6.95, z, rotationY: Math.PI / 2 });
+  });
+
+  [-15.4, -12.5, -9.6, -6.7].forEach((z) => {
+    slots.push({ x: centerX + 6.95, z, rotationY: -Math.PI / 2 });
+  });
+
+  [-3.1, 0, 3.1].forEach((offsetX) => {
+    slots.push({ x: centerX + offsetX, z: 1.34, rotationY: Math.PI });
+  });
+
+  return slots.slice(0, count);
+}
+
+async function addArtwork(artwork, slot) {
+  const normal = new THREE.Vector3(0, 0, 1).applyAxisAngle(new THREE.Vector3(0, 1, 0), slot.rotationY);
+  const wallPosition = new THREE.Vector3(slot.x, 2.42, slot.z).addScaledVector(normal, 0.1);
+  const texture = await textureFor(artwork.properties.thumbnail.trim());
+
+  const frameMaterial = new THREE.MeshStandardMaterial({ color: 0x211f1c, roughness: 0.38, metalness: 0.12 });
+  const frame = trackArtwork(new THREE.Mesh(new THREE.BoxGeometry(2.28, 1.76, 0.14), frameMaterial));
+  frame.position.copy(wallPosition);
+  frame.rotation.y = slot.rotationY;
   frame.castShadow = true;
-  const mat = addTracked(new THREE.Mesh(new THREE.BoxGeometry(2.06, 1.54, 0.06), new THREE.MeshStandardMaterial({ color: 0xf7f2e9, roughness: 0.9 })));
-  mat.position.copy(artPos).addScaledVector(normal, 0.06);
-  mat.rotation.y = rotationY;
-  const image = addTracked(new THREE.Mesh(new THREE.PlaneGeometry(1.82, 1.3), new THREE.MeshBasicMaterial({ map: texture })));
-  image.position.copy(artPos).addScaledVector(normal, 0.105);
-  image.rotation.y = rotationY;
-  image.userData.artwork = artwork;
-  image.userData.focus = artPos.clone().addScaledVector(normal, 4.6).setY(2.35);
-  image.userData.target = artPos.clone();
+  frame.userData.defaultMaterial = frameMaterial;
+
+  const matBoard = trackArtwork(new THREE.Mesh(
+    new THREE.BoxGeometry(2.02, 1.5, 0.05),
+    new THREE.MeshStandardMaterial({ color: 0xf8f1e7, roughness: 0.92 })
+  ));
+  matBoard.position.copy(wallPosition).addScaledVector(normal, 0.055);
+  matBoard.rotation.y = slot.rotationY;
+
+  const imageMaterial = texture
+    ? new THREE.MeshBasicMaterial({ map: texture })
+    : new THREE.MeshBasicMaterial({ color: 0xb9aa98 });
+  const image = trackArtwork(new THREE.Mesh(new THREE.PlaneGeometry(1.78, 1.24), imageMaterial));
+  image.position.copy(wallPosition).addScaledVector(normal, 0.095);
+  image.rotation.y = slot.rotationY;
+  image.userData = {
+    artwork,
+    frame,
+    focus: wallPosition.clone().addScaledVector(normal, 3.45).setY(2.35),
+    target: wallPosition.clone()
+  };
+
   clickable.push(image);
   state.displayed.push({ artwork, object: image });
 
-  const p = artwork.properties;
-  createHtmlLabel(`${p.title || 'Untitled'}\n${p.artist || 'Unknown'}${p.year ? `, ${p.year}` : ''}`, artPos.x, 0.82, artPos.z);
+  const props = artwork.properties;
+  createLabel(
+    `${props.title || 'Untitled'}\n${props.artist || 'Unknown'}${props.year ? `, ${props.year}` : ''}`,
+    wallPosition.x,
+    1.05,
+    wallPosition.z
+  );
 }
 
-function galleryPositions(count) {
-  const positions = [];
-  const perRow = Math.min(7, Math.max(3, Math.ceil(Math.sqrt(count))));
-  for (let index = 0; index < count; index += 1) {
-    const row = Math.floor(index / perRow);
-    const col = index % perRow;
-    positions.push({ x: (col - (perRow - 1) / 2) * 4.8, z: -10.2 + row * 4.7, rotationY: 0 });
+async function renderGallery(galleryKey) {
+  const token = state.renderToken + 1;
+  state.renderToken = token;
+  state.currentGallery = galleryKey;
+  els.mode.value = galleryKey;
+  els.topicControl.classList.toggle('hidden', galleryKey !== 'topic');
+  els.modeLabel.textContent = GALLERIES[galleryKey].name;
+  clearArtworkDisplay();
+
+  const selection = selectForGallery(galleryKey);
+  const slots = slotsForGallery(galleryKey, selection.length);
+  els.count.textContent = slots.length;
+
+  for (let index = 0; index < slots.length; index += 1) {
+    if (state.renderToken !== token) return;
+    await addArtwork(selection[index], slots[index]);
   }
-  return positions;
+
+  focusGallery(galleryKey);
 }
 
-function layoutLine(artworks, heading) {
-  createHtmlLabel(heading, 0, 5.0, -10.2, 'gallery-label--section');
-  const selected = artworks.slice(0, MAX_ARTWORKS);
-  galleryPositions(selected.length).forEach((pos, index) => addArtwork(selected[index], pos.x, pos.z, pos.rotationY));
-  els.count.textContent = selected.length;
-}
-
-function layoutContinents() {
-  const groups = state.artworks.reduce((acc, artwork) => {
-    const continent = artwork.properties.continent || 'Other';
-    if (!acc.has(continent)) acc.set(continent, []);
-    acc.get(continent).push(artwork);
-    return acc;
-  }, new Map());
-  const continents = [...groups.keys()].sort();
-  const positions = galleryPositions(continents.length * MAX_PER_CONTINENT);
-  let used = 0;
-  continents.forEach((continent) => {
-    groups.get(continent).sort(byYearAscending).slice(0, MAX_PER_CONTINENT).forEach((artwork, index) => {
-      const pos = positions[used];
-      addArtwork(artwork, pos.x, pos.z, pos.rotationY, index === 0 ? continent : '');
-      used += 1;
-    });
-  });
-  els.count.textContent = used;
-}
-
-function currentSelection() {
-  if (els.mode.value === 'continent') return null;
-  if (els.mode.value === 'topic') return state.artworks.filter((a) => a.properties.clusters.includes(els.topic.value) || topicsFor(a).includes(els.topic.value)).sort(byYearAscending);
-  return [...state.artworks].sort(byYearAscending);
-}
-
-function renderMode() {
-  clearExhibition();
-  els.topicControl.classList.toggle('hidden', els.mode.value !== 'topic');
-  els.modeLabel.textContent = els.mode.selectedOptions[0].textContent;
-  if (els.mode.value === 'continent') layoutContinents();
-  else {
-    const selected = currentSelection();
-    layoutLine(selected, els.mode.value === 'timeline' ? 'Chronological gallery path' : els.topic.value);
-  }
-  focusOverview();
-}
-
-function populateControls() {
+function populateTopicControl() {
   const topics = new Set(Object.keys(state.topicClusters));
-  state.artworks.forEach((a) => topicsFor(a).forEach((topic) => topics.add(topic)));
+  state.artworks.forEach((artwork) => topicsFor(artwork).forEach((topic) => topics.add(topic)));
   els.topic.innerHTML = [...topics].sort().map((topic) => `<option>${escapeHtml(topic)}</option>`).join('');
 }
 
 function showInfo(artwork) {
-  const p = artwork.properties;
-  els.info.innerHTML = `<h2 class="text-xl font-semibold">${escapeHtml(p.title || 'Untitled')}</h2><dl>
-    <div><dt>Artist</dt><dd>${escapeHtml(p.artist || 'Unknown')}</dd></div>
-    <div><dt>Year</dt><dd>${escapeHtml(p.year || 'Unknown')}</dd></div>
-    <div><dt>Continent</dt><dd>${escapeHtml(p.continent || 'Other')}</dd></div>
-    <div><dt>Location</dt><dd>${escapeHtml(p.location || 'Unknown')}</dd></div>
+  const props = artwork.properties;
+  els.info.innerHTML = `<h2 class="text-xl font-semibold">${escapeHtml(props.title || 'Untitled')}</h2><dl>
+    <div><dt>Artist</dt><dd>${escapeHtml(props.artist || 'Unknown')}</dd></div>
+    <div><dt>Year</dt><dd>${escapeHtml(props.year || 'Unknown')}</dd></div>
+    <div><dt>Continent</dt><dd>${escapeHtml(props.continent || 'Other')}</dd></div>
+    <div><dt>Location</dt><dd>${escapeHtml(props.location || 'Unknown')}</dd></div>
     <div><dt>Topics</dt><dd>${escapeHtml(topicsFor(artwork).join(', ') || 'Uncategorized')}</dd></div>
-    <div><dt>Description</dt><dd>${escapeHtml((p.description || 'No description available.').slice(0, 240))}${p.description?.length > 240 ? '…' : ''}</dd></div>
-    ${p.url ? `<div><dt>Source</dt><dd><a href="${escapeHtml(p.url)}" target="_blank" rel="noopener">Open source link</a></dd></div>` : ''}
+    <div><dt>Description</dt><dd>${escapeHtml((props.description || 'No description available.').slice(0, 240))}${props.description?.length > 240 ? '…' : ''}</dd></div>
+    ${props.url ? `<div><dt>Source</dt><dd><a href="${escapeHtml(props.url)}" target="_blank" rel="noopener">Open source link</a></dd></div>` : ''}
   </dl>`;
 }
 
-function escapeHtml(value) {
-  return String(value).replace(/[&<>'"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[char]));
+function updateSelectionHighlight() {
+  state.displayed.forEach((item, index) => {
+    const frame = item.object.userData.frame;
+    frame.material = index === state.selectedIndex ? selectedFrameMaterial : frame.userData.defaultMaterial;
+  });
 }
 
 function focusArtwork(index) {
@@ -256,16 +430,26 @@ function focusArtwork(index) {
   state.selectedIndex = (index + state.displayed.length) % state.displayed.length;
   const item = state.displayed[state.selectedIndex];
   showInfo(item.artwork);
+  updateSelectionHighlight();
   state.cameraGoal = {
     position: item.object.userData.focus,
     target: item.object.userData.target
   };
 }
 
-function focusOverview() {
+function focusGallery(galleryKey) {
+  const gallery = GALLERIES[galleryKey];
   state.cameraGoal = {
-    position: new THREE.Vector3(0, 4.2, 15.5),
-    target: new THREE.Vector3(0, 1.85, -3.2)
+    position: gallery.overview.clone(),
+    target: gallery.target.clone()
+  };
+}
+
+function focusEntrance() {
+  els.modeLabel.textContent = 'Entrance';
+  state.cameraGoal = {
+    position: new THREE.Vector3(0, 4.1, 11.6),
+    target: new THREE.Vector3(0, 1.9, -1.7)
   };
 }
 
@@ -276,8 +460,7 @@ function onPointerDown(event) {
   raycaster.setFromCamera(pointer, camera);
   const hit = raycaster.intersectObjects(clickable)[0];
   if (hit?.object.userData.artwork) {
-    const index = state.displayed.findIndex((item) => item.object === hit.object);
-    focusArtwork(index);
+    focusArtwork(state.displayed.findIndex((item) => item.object === hit.object));
   }
 }
 
@@ -295,16 +478,18 @@ function updateLabels() {
     const projected = label.userData.position.clone().project(camera);
     label.style.left = `${(projected.x * 0.5 + 0.5) * width}px`;
     label.style.top = `${(-projected.y * 0.5 + 0.5) * height}px`;
-    label.style.display = projected.z > 1 ? 'none' : '';
+    label.style.display = projected.z > 1 || Math.abs(projected.x) > 1.12 || Math.abs(projected.y) > 1.12 ? 'none' : '';
   });
 }
 
 function animate() {
   requestAnimationFrame(animate);
   if (state.cameraGoal) {
-    camera.position.lerp(state.cameraGoal.position, 0.075);
-    controls.target.lerp(state.cameraGoal.target, 0.075);
-    if (camera.position.distanceTo(state.cameraGoal.position) < 0.04 && controls.target.distanceTo(state.cameraGoal.target) < 0.04) state.cameraGoal = null;
+    camera.position.lerp(state.cameraGoal.position, 0.085);
+    controls.target.lerp(state.cameraGoal.target, 0.085);
+    if (camera.position.distanceTo(state.cameraGoal.position) < 0.035 && controls.target.distanceTo(state.cameraGoal.target) < 0.035) {
+      state.cameraGoal = null;
+    }
   }
   controls.update();
   updateLabels();
@@ -312,23 +497,28 @@ function animate() {
 }
 
 async function init() {
-  initEnvironment();
+  initArchitecture();
   const data = await EcoData.loadSharedData();
   state.topicClusters = data.topicClusters;
   state.artworks = data.artworkData.features
     .map((artwork) => EcoData.enrichArtwork(artwork, data))
     .filter(hasThumbnail);
-  populateControls();
-  renderMode();
+
+  populateTopicControl();
+  await renderGallery('continent');
+  focusEntrance();
   resize();
   animate();
 }
 
-els.mode.addEventListener('change', renderMode);
-els.topic.addEventListener('change', renderMode);
+els.mode.addEventListener('change', () => renderGallery(els.mode.value));
+els.topic.addEventListener('change', () => renderGallery('topic'));
+els.enterContinents.addEventListener('click', () => renderGallery('continent'));
+els.enterTopics.addEventListener('click', () => renderGallery('topic'));
+els.enterTimeline.addEventListener('click', () => renderGallery('timeline'));
 els.previous.addEventListener('click', () => focusArtwork(state.selectedIndex - 1));
 els.next.addEventListener('click', () => focusArtwork(state.selectedIndex + 1));
-els.overview.addEventListener('click', focusOverview);
+els.overview.addEventListener('click', focusEntrance);
 renderer.domElement.addEventListener('pointerdown', onPointerDown);
 window.addEventListener('resize', resize);
 

--- a/exhibition.html
+++ b/exhibition.html
@@ -38,16 +38,24 @@
 
     <main class="exhibition-shell">
         <section class="exhibition-stage">
-            <div id="exhibitionCanvas" class="exhibition-canvas" aria-label="3D museum-style virtual exhibition"></div>
-            <div class="exhibition-help">Use Previous / Next for a guided tour • Reset returns to the full gallery • Drag gently to adjust the view • Click framed artworks for details</div>
+            <div id="exhibitionCanvas" class="exhibition-canvas" aria-label="3D curated futuristic indoor museum exhibition"></div>
+            <div class="exhibition-help">Use the gallery buttons and Previous / Next to move through the exhibition.</div>
         </section>
 
         <aside class="exhibition-panel bg-base-200">
-            <h1 class="text-2xl font-bold">Virtual Museum Gallery</h1>
-            <p class="mt-3 text-sm opacity-80">A calm, curated room of framed eco:nection artworks with wall labels, gallery lighting, and simple guided navigation.</p>
+            <h1 class="text-2xl font-bold">Curated Museum Exhibition</h1>
+            <p class="mt-3 text-sm opacity-80">A guided indoor digital museum with architectural rooms, framed archive works, controlled lighting, and subtle futuristic materials.</p>
+            <p class="exhibition-rotation-note mt-3 text-xs">Showing a monthly rotating selection from the archive.</p>
+
+            <div class="exhibition-tour mt-5" aria-label="Guided gallery navigation">
+                <button id="enterContinents" class="btn btn-primary btn-sm"><i class="ti ti-door-enter"></i>Enter / View Continent Gallery</button>
+                <button id="enterTopics" class="btn btn-primary btn-sm"><i class="ti ti-door-enter"></i>Enter / View Topic Gallery</button>
+                <button id="enterTimeline" class="btn btn-primary btn-sm"><i class="ti ti-door-enter"></i>Enter / View Timeline Gallery</button>
+                <button id="overviewGallery" class="btn btn-ghost btn-sm"><i class="ti ti-home"></i>Back to Entrance / Overview</button>
+            </div>
 
             <label class="form-control mt-5">
-                <span class="label-text">Curatorial mode</span>
+                <span class="label-text">Gallery mode</span>
                 <select id="exhibitionMode" class="select select-bordered">
                     <option value="continent" selected>Continent</option>
                     <option value="topic">Topic</option>
@@ -63,18 +71,17 @@
             <div class="exhibition-tour mt-5" aria-label="Guided artwork navigation">
                 <button id="previousArtwork" class="btn btn-outline btn-sm"><i class="ti ti-chevron-left"></i>Previous artwork</button>
                 <button id="nextArtwork" class="btn btn-primary btn-sm">Next artwork<i class="ti ti-chevron-right"></i></button>
-                <button id="overviewGallery" class="btn btn-ghost btn-sm"><i class="ti ti-home"></i>Reset / Overview</button>
             </div>
-            <p class="mt-3 text-xs opacity-70">Tip: the guided buttons move between works in the current curatorial sequence. Orbit controls are available only for small adjustments.</p>
+            <p class="mt-3 text-xs opacity-70">Orbit controls are available only for small viewing adjustments; the gallery buttons provide the primary desktop and touch navigation.</p>
 
             <div class="stats stats-vertical shadow w-full mt-5">
                 <div class="stat"><div class="stat-title">Displayed artworks</div><div id="exhibitionCount" class="stat-value text-primary">0</div></div>
-                <div class="stat"><div class="stat-title">Mode</div><div id="exhibitionModeLabel" class="stat-value text-secondary text-lg">Continent</div></div>
+                <div class="stat"><div class="stat-title">Current gallery</div><div id="exhibitionModeLabel" class="stat-value text-secondary text-lg">Entrance</div></div>
             </div>
 
             <section id="artworkInfo" class="exhibition-info mt-5 rounded-box border border-base-300 bg-base-100 p-4">
-                <h2 class="text-xl font-semibold">Begin the guided tour</h2>
-                <p class="mt-2 text-sm opacity-75">Select Next artwork or click a framed work to view artwork details here.</p>
+                <h2 class="text-xl font-semibold">Entrance / Overview</h2>
+                <p class="mt-2 text-sm opacity-75">Choose a gallery or select Next artwork to begin the curated tour.</p>
             </section>
         </aside>
     </main>

--- a/exhibition.html
+++ b/exhibition.html
@@ -38,24 +38,23 @@
 
     <main class="exhibition-shell">
         <section class="exhibition-stage">
-            <div id="exhibitionCanvas" class="exhibition-canvas" aria-label="3D curated futuristic indoor museum exhibition"></div>
-            <div class="exhibition-help">Use the gallery buttons and Previous / Next to move through the exhibition.</div>
+            <div id="exhibitionCanvas" class="exhibition-canvas" aria-label="3D indoor museum virtual exhibition"></div>
+            <div class="exhibition-help">Use the room buttons and Previous / Next to move through the exhibition.</div>
         </section>
 
         <aside class="exhibition-panel bg-base-200">
-            <h1 class="text-2xl font-bold">Curated Museum Exhibition</h1>
-            <p class="mt-3 text-sm opacity-80">A guided indoor digital museum with architectural rooms, framed archive works, controlled lighting, and subtle futuristic materials.</p>
-            <p class="exhibition-rotation-note mt-3 text-xs">Showing a monthly rotating selection from the archive.</p>
+            <h1 class="text-2xl font-bold">Indoor Museum Exhibition</h1>
+            <p class="mt-3 text-sm opacity-80">Enter enclosed gallery rooms with framed artworks, wall signs, ceiling, warm lighting, and guided room-based navigation.</p>
 
-            <div class="exhibition-tour mt-5" aria-label="Guided gallery navigation">
-                <button id="enterContinents" class="btn btn-primary btn-sm"><i class="ti ti-door-enter"></i>Enter / View Continent Gallery</button>
-                <button id="enterTopics" class="btn btn-primary btn-sm"><i class="ti ti-door-enter"></i>Enter / View Topic Gallery</button>
-                <button id="enterTimeline" class="btn btn-primary btn-sm"><i class="ti ti-door-enter"></i>Enter / View Timeline Gallery</button>
-                <button id="overviewGallery" class="btn btn-ghost btn-sm"><i class="ti ti-home"></i>Back to Entrance / Overview</button>
+            <div class="exhibition-tour mt-5" aria-label="Guided room navigation">
+                <button id="enterContinents" class="btn btn-primary btn-sm"><i class="ti ti-door-enter"></i>Enter Continents Room</button>
+                <button id="enterTopics" class="btn btn-primary btn-sm"><i class="ti ti-door-enter"></i>Enter Topics Room</button>
+                <button id="enterTimeline" class="btn btn-primary btn-sm"><i class="ti ti-door-enter"></i>Enter Timeline Room</button>
+                <button id="overviewGallery" class="btn btn-ghost btn-sm"><i class="ti ti-home"></i>Back to entrance / Overview</button>
             </div>
 
             <label class="form-control mt-5">
-                <span class="label-text">Gallery mode</span>
+                <span class="label-text">Room mode</span>
                 <select id="exhibitionMode" class="select select-bordered">
                     <option value="continent" selected>Continent</option>
                     <option value="topic">Topic</option>
@@ -72,16 +71,16 @@
                 <button id="previousArtwork" class="btn btn-outline btn-sm"><i class="ti ti-chevron-left"></i>Previous artwork</button>
                 <button id="nextArtwork" class="btn btn-primary btn-sm">Next artwork<i class="ti ti-chevron-right"></i></button>
             </div>
-            <p class="mt-3 text-xs opacity-70">Orbit controls are available only for small viewing adjustments; the gallery buttons provide the primary desktop and touch navigation.</p>
+            <p class="mt-3 text-xs opacity-70">Orbit controls are constrained and only intended for small viewing adjustments; use the buttons for reliable desktop and touch navigation.</p>
 
             <div class="stats stats-vertical shadow w-full mt-5">
                 <div class="stat"><div class="stat-title">Displayed artworks</div><div id="exhibitionCount" class="stat-value text-primary">0</div></div>
-                <div class="stat"><div class="stat-title">Current gallery</div><div id="exhibitionModeLabel" class="stat-value text-secondary text-lg">Entrance</div></div>
+                <div class="stat"><div class="stat-title">Current room</div><div id="exhibitionModeLabel" class="stat-value text-secondary text-lg">Continent</div></div>
             </div>
 
             <section id="artworkInfo" class="exhibition-info mt-5 rounded-box border border-base-300 bg-base-100 p-4">
-                <h2 class="text-xl font-semibold">Entrance / Overview</h2>
-                <p class="mt-2 text-sm opacity-75">Choose a gallery or select Next artwork to begin the curated tour.</p>
+                <h2 class="text-xl font-semibold">Welcome to the entrance lobby</h2>
+                <p class="mt-2 text-sm opacity-75">Choose a room or select Next artwork to begin the guided tour.</p>
             </section>
         </aside>
     </main>


### PR DESCRIPTION
### Motivation
- Refresh the virtual exhibition with a more immersive indoor museum design, improved lighting and materials for a curated presentation. 
- Support multiple curated gallery modes (continent, topic, timeline) and surface a larger rotating selection of archive artworks. 
- Improve UX and reliability for thumbnails and navigation with controlled camera positions and deterministic monthly rotation. 

### Description
- Reworked styles in `assets/css/exhibition.css` to adjust stage sizing, colors, label styles, help overlay, add a `.exhibition-rotation-note` and make canvas/touch behavior changes. 
- Large refactor of `assets/js/exhibition.js` introducing gallery metadata in `GALLERIES`, separate tracking of `architectureObjects` vs `artworkObjects`, new camera positions, updated `OrbitControls` limits, and different renderer settings (pixel ratio, shadow map type, output color space). 
- Implemented deterministic monthly rotation and seeded shuffling via `hashString`, `seededRandom`, and `monthlyRotate`; increased totals and per-continent/topic limits and added `selectForGallery`, `slotsForGallery`, `renderGallery` (async, cancelable via `renderToken`) and `addArtwork` for slot-based placement. 
- Replaced older scene construction with `initArchitecture` that builds walls/floor/ceiling, multiple spotlights, gallery labels, and new materials; improved thumbnail loading with a timeout in `textureFor`; added safe HTML escaping with `escapeHtml` and selection highlighting material. 
- Updated input wiring and UI in `exhibition.html` to add gallery entry buttons, update copy, expose `enterContinents`, `enterTopics`, `enterTimeline` events, and adjust the mode/overview controls and info text. 

### Testing
- No automated tests were added or executed for this UI change (no existing automated test coverage for the exhibition module).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3f8a26048330a98d3558c9de6834)